### PR TITLE
feat: add modular codegen architecture matching ash_typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 ash_typescript contributors <https://github.com/ash-project/ash_typescript/graphs.contributors>
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
 #
 # SPDX-License-Identifier: MIT
 
@@ -21,11 +21,10 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-ash_typescript-*.tar
+ash_kotlin_multiplatform-*.tar
 
 # Temporary files, for example, from tests.
 /tmp/
 
-test/ts/node_modules/
-test/ts/generated.ts
-test/ts/**/*.js
+# Generated Kotlin files (if output to project directory)
+*.kt.generated

--- a/lib/ash_kotlin_multiplatform.ex
+++ b/lib/ash_kotlin_multiplatform.ex
@@ -186,4 +186,45 @@ defmodule AshKotlinMultiplatform do
   def generate_validation_annotations? do
     Application.get_env(:ash_kotlin_multiplatform, :generate_validation_annotations, false)
   end
+
+  @doc """
+  Returns whether the given resource requires a tenant parameter.
+
+  This is determined by the resource's multitenancy configuration.
+  """
+  def requires_tenant_parameter?(resource) do
+    case Ash.Resource.Info.multitenancy_strategy(resource) do
+      nil -> Application.get_env(:ash_kotlin_multiplatform, :require_tenant_parameters, false)
+      _ -> true
+    end
+  rescue
+    _ -> false
+  end
+
+  @doc """
+  Returns the before request hook for RPC actions.
+
+  The hook is a Kotlin function name that will be called before each request.
+  """
+  def rpc_action_before_request_hook do
+    Application.get_env(:ash_kotlin_multiplatform, :rpc_action_before_request_hook, nil)
+  end
+
+  @doc """
+  Returns the after request hook for RPC actions.
+
+  The hook is a Kotlin function name that will be called after each request.
+  """
+  def rpc_action_after_request_hook do
+    Application.get_env(:ash_kotlin_multiplatform, :rpc_action_after_request_hook, nil)
+  end
+
+  @doc """
+  Returns the field names callback to use for interop.
+
+  Defaults to :interop_field_names.
+  """
+  def field_names_callback do
+    Application.get_env(:ash_kotlin_multiplatform, :field_names_callback, :interop_field_names)
+  end
 end

--- a/lib/ash_kotlin_multiplatform/resource.ex
+++ b/lib/ash_kotlin_multiplatform/resource.ex
@@ -50,5 +50,9 @@ defmodule AshKotlinMultiplatform.Resource do
   }
 
   use Spark.Dsl.Extension,
-    sections: [@kotlin_multiplatform]
+    sections: [@kotlin_multiplatform],
+    verifiers: [
+      AshKotlinMultiplatform.Resource.Verifiers.VerifyFieldNames,
+      AshKotlinMultiplatform.Resource.Verifiers.VerifyUniqueTypeNames
+    ]
 end

--- a/lib/ash_kotlin_multiplatform/resource/info.ex
+++ b/lib/ash_kotlin_multiplatform/resource/info.ex
@@ -65,4 +65,50 @@ defmodule AshKotlinMultiplatform.Resource.Info do
   rescue
     _ -> false
   end
+
+  @doc """
+  Checks if a resource has the AshKotlinMultiplatform.Resource extension.
+  """
+  def kotlin_multiplatform_resource?(resource) do
+    extensions = Spark.extensions(resource)
+    AshKotlinMultiplatform.Resource in extensions
+  rescue
+    _ -> false
+  end
+
+  @doc """
+  Returns the Kotlin type name for a resource, falling back to the module name.
+  """
+  def kotlin_multiplatform_type_name!(resource) do
+    case kotlin_multiplatform_type_name(resource) do
+      nil ->
+        resource
+        |> Module.split()
+        |> List.last()
+
+      name ->
+        name
+    end
+  end
+
+  @doc """
+  Returns the field name mappings for a resource (always returns a list).
+  """
+  def kotlin_multiplatform_field_names!(resource) do
+    kotlin_multiplatform_field_names(resource) || []
+  end
+
+  @doc """
+  Gets the mapped field name for a given field.
+
+  Returns the mapped name if a mapping exists, otherwise returns the original field name.
+  """
+  def get_mapped_field_name(resource, field_name) do
+    field_names = kotlin_multiplatform_field_names(resource)
+
+    case Keyword.get(field_names, field_name) do
+      nil -> field_name
+      mapped -> mapped
+    end
+  end
 end

--- a/lib/ash_kotlin_multiplatform/resource/verifiers/verify_field_names.ex
+++ b/lib/ash_kotlin_multiplatform/resource/verifiers/verify_field_names.ex
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Resource.Verifiers.VerifyFieldNames do
+  @moduledoc """
+  Verifies that resource field names are valid for Kotlin code generation.
+
+  Checks public attributes, relationships, calculations, and aggregates to ensure
+  they don't contain invalid patterns like question marks or numbers preceded by underscores.
+  """
+  use Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl) do
+    dsl[:persist][:module]
+    |> validate_resource_field_names()
+    |> case do
+      [] -> :ok
+      errors -> format_name_validation_errors(errors)
+    end
+  end
+
+  @doc false
+  def invalid_name?(name) do
+    Regex.match?(~r/_+\d|\?/, to_string(name))
+  end
+
+  @doc false
+  def make_name_better(name) do
+    name
+    |> to_string()
+    |> String.replace(~r/_+\d/, fn v ->
+      String.trim_leading(v, "_")
+    end)
+    |> String.replace("?", "")
+  end
+
+  defp validate_resource_field_names(resource) do
+    invalid_fields = []
+
+    # Check public attributes
+    invalid_fields =
+      invalid_fields ++
+        (Ash.Resource.Info.public_attributes(resource)
+         |> Enum.filter(fn attr ->
+           mapped_name =
+             AshKotlinMultiplatform.Resource.Info.get_mapped_field_name(resource, attr.name)
+
+           invalid_name?(mapped_name)
+         end)
+         |> Enum.map(fn attr -> {:attribute, attr.name, make_name_better(attr.name)} end))
+
+    # Check public relationships
+    invalid_fields =
+      invalid_fields ++
+        (Ash.Resource.Info.public_relationships(resource)
+         |> Enum.filter(fn rel ->
+           mapped_name =
+             AshKotlinMultiplatform.Resource.Info.get_mapped_field_name(resource, rel.name)
+
+           invalid_name?(mapped_name)
+         end)
+         |> Enum.map(fn rel -> {:relationship, rel.name, make_name_better(rel.name)} end))
+
+    # Check public calculations
+    invalid_fields =
+      invalid_fields ++
+        (Ash.Resource.Info.public_calculations(resource)
+         |> Enum.filter(fn calc ->
+           mapped_name =
+             AshKotlinMultiplatform.Resource.Info.get_mapped_field_name(resource, calc.name)
+
+           invalid_name?(mapped_name)
+         end)
+         |> Enum.map(fn calc -> {:calculation, calc.name, make_name_better(calc.name)} end))
+
+    # Check public aggregates
+    invalid_fields =
+      invalid_fields ++
+        (Ash.Resource.Info.public_aggregates(resource)
+         |> Enum.filter(fn agg ->
+           mapped_name =
+             AshKotlinMultiplatform.Resource.Info.get_mapped_field_name(resource, agg.name)
+
+           invalid_name?(mapped_name)
+         end)
+         |> Enum.map(fn agg -> {:aggregate, agg.name, make_name_better(agg.name)} end))
+
+    case invalid_fields do
+      [] -> []
+      _ -> [{:invalid_resource_fields, resource, invalid_fields}]
+    end
+  end
+
+  defp format_name_validation_errors(errors) do
+    message_parts = Enum.map_join(errors, "\n\n", &format_error_part/1)
+
+    {:error,
+     Spark.Error.DslError.exception(
+       message: """
+       Invalid field names found that contain question marks, or numbers preceded by underscores.
+       These patterns are not allowed in Kotlin code generation.
+
+       #{message_parts}
+
+       Names should use standard camelCase or snake_case patterns without numbered suffixes.
+       You can use field_names in the kotlin_multiplatform section to provide valid alternatives.
+       """
+     )}
+  end
+
+  defp format_error_part({:invalid_resource_fields, resource, fields}) do
+    suggestions =
+      Enum.map_join(fields, "\n", fn {type, current, suggested} ->
+        "  - #{type} #{current} → #{suggested}"
+      end)
+
+    "Invalid field names in resource #{resource}:\n#{suggestions}"
+  end
+end

--- a/lib/ash_kotlin_multiplatform/resource/verifiers/verify_unique_type_names.ex
+++ b/lib/ash_kotlin_multiplatform/resource/verifiers/verify_unique_type_names.ex
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Resource.Verifiers.VerifyUniqueTypeNames do
+  @moduledoc """
+  Checks that all resources using AshKotlinMultiplatform.Resource have unique type_name values.
+  """
+  use Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl) do
+    current_resource = dsl[:persist][:module]
+
+    first_kotlin_resource =
+      Mix.Project.config()[:app]
+      |> Ash.Info.domains()
+      |> Enum.find_value(fn domain ->
+        domain
+        |> Ash.Domain.Info.resources()
+        |> Enum.find(&AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_resource?/1)
+      end)
+
+    if current_resource == first_kotlin_resource do
+      all_type_names =
+        Mix.Project.config()[:app]
+        |> Ash.Info.domains()
+        |> Enum.flat_map(fn domain ->
+          domain
+          |> Ash.Domain.Info.resources()
+          |> Enum.filter(&AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_resource?/1)
+        end)
+        |> Enum.uniq()
+        |> Enum.map(fn resource ->
+          type_name = AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_type_name!(resource)
+          {type_name, resource}
+        end)
+
+      # Group by type name to find duplicates
+      duplicates =
+        all_type_names
+        |> Enum.group_by(&elem(&1, 0))
+        |> Enum.filter(fn {_, resources} ->
+          case resources do
+            [_single] -> false
+            _ -> true
+          end
+        end)
+        |> Enum.map(fn {type_name, resources} ->
+          resource_names =
+            Enum.map(resources, fn {_, resource} ->
+              resource |> to_string() |> String.trim("Elixir.")
+            end)
+
+          {type_name, resource_names}
+        end)
+
+      case duplicates do
+        [] ->
+          :ok
+
+        _ ->
+          duplicate_messages =
+            Enum.map(duplicates, fn {type_name, resource_names} ->
+              "Type name '#{type_name}' is used by: #{Enum.join(resource_names, ", ")}"
+            end)
+
+          {:error,
+           Spark.Error.DslError.exception(
+             message: """
+             Duplicate Kotlin type names found:
+             #{Enum.join(duplicate_messages, "\n")}
+
+             Each resource using AshKotlinMultiplatform.Resource must have a unique type_name.
+             """
+           )}
+      end
+    else
+      # For all other resources, just return :ok - the check is done by the first resource
+      :ok
+    end
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc.ex
+++ b/lib/ash_kotlin_multiplatform/rpc.ex
@@ -180,7 +180,12 @@ defmodule AshKotlinMultiplatform.Rpc do
     ]
   }
 
-  use Spark.Dsl.Extension, sections: [@rpc]
+  use Spark.Dsl.Extension,
+    sections: [@rpc],
+    verifiers: [
+      AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities,
+      AshKotlinMultiplatform.Rpc.Verifiers.VerifyActionTypes
+    ]
 
   @doc """
   Returns the input field formatter for RPC requests.

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/function_generators/function_core.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/function_generators/function_core.ex
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.FunctionGenerators.FunctionCore do
+  @moduledoc """
+  Builds the common "shape" of RPC functions, independent of transport.
+
+  This module extracts all the shared logic between HTTP and Channel function generation,
+  returning a structured map that renderers use to emit transport-specific Kotlin code.
+  """
+
+  alias AshKotlinMultiplatform.Rpc.Codegen.Helpers.{ActionIntrospection, ConfigBuilder}
+  alias AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.MetadataTypes
+  alias AshIntrospection.Helpers
+
+  @doc """
+  Builds the execution function shape for both HTTP and Channel transports.
+
+  Returns a map containing:
+  - Basic metadata (resource, action, names, context)
+  - Field selection info (has_fields)
+  - Pagination info
+  - Metadata info
+  """
+  def build_execution_function_shape(resource, action, rpc_action, rpc_action_name, opts \\ []) do
+    transport = Keyword.get(opts, :transport, :http)
+
+    rpc_action_name_pascal = Helpers.snake_to_pascal_case(rpc_action_name)
+    resource_name = build_resource_type_name(resource)
+    context = ConfigBuilder.get_action_context(resource, action, rpc_action)
+
+    # Check metadata configuration
+    has_metadata =
+      MetadataTypes.metadata_enabled?(
+        MetadataTypes.get_exposed_metadata_fields(rpc_action, action)
+      )
+
+    # Determine field selection capabilities
+    has_fields = action.type != :destroy
+
+    is_optional_pagination =
+      action.type == :read and
+        not context.is_get_action and
+        ActionIntrospection.action_supports_pagination?(action) and
+        not ActionIntrospection.action_requires_pagination?(action) and
+        has_fields
+
+    %{
+      resource: resource,
+      action: action,
+      rpc_action: rpc_action,
+      rpc_action_name: rpc_action_name,
+      rpc_action_name_pascal: rpc_action_name_pascal,
+      resource_name: resource_name,
+      context: context,
+      has_fields: has_fields,
+      has_metadata: has_metadata,
+      is_optional_pagination: is_optional_pagination,
+      is_mutation: action.type in [:create, :update],
+      transport: transport
+    }
+  end
+
+  @doc """
+  Builds the validation function shape for both HTTP and Channel transports.
+
+  Validation functions are simpler - they don't have field selection, pagination, etc.
+  They just validate input and return validation errors.
+  """
+  def build_validation_function_shape(resource, action, rpc_action, rpc_action_name, _opts \\ []) do
+    rpc_action_name_pascal = Helpers.snake_to_pascal_case(rpc_action_name)
+    context = ConfigBuilder.get_action_context(resource, action, rpc_action)
+
+    %{
+      resource: resource,
+      action: action,
+      rpc_action_name: rpc_action_name,
+      rpc_action_name_pascal: rpc_action_name_pascal,
+      context: context
+    }
+  end
+
+  @doc """
+  Builds the Kotlin resource type name for a resource.
+  """
+  def build_resource_type_name(resource) do
+    case AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_type_name(resource) do
+      nil ->
+        resource
+        |> Module.split()
+        |> List.last()
+
+      name ->
+        name
+    end
+  rescue
+    _ ->
+      resource
+      |> Module.split()
+      |> List.last()
+  end
+
+  @doc """
+  Determines the return type for an action.
+  """
+  def determine_return_type(shape) do
+    action = shape.action
+    resource_name = shape.resource_name
+    context = shape.context
+
+    cond do
+      action.type == :destroy ->
+        "Boolean"
+
+      action.type == :action ->
+        # Generic action - check return type
+        case ActionIntrospection.action_returns_field_selectable_type?(action) do
+          {:ok, :resource, _} ->
+            "#{resource_name}"
+
+          {:ok, :array_of_resource, _} ->
+            "List<#{resource_name}>"
+
+          {:ok, :typed_map, _} ->
+            "Map<String, @Contextual Any?>"
+
+          {:ok, :unconstrained_map, _} ->
+            "Map<String, @Contextual Any?>"
+
+          _ ->
+            "Map<String, @Contextual Any?>"
+        end
+
+      action.type == :read and context.is_get_action ->
+        "#{resource_name}?"
+
+      action.type == :read and context.supports_pagination ->
+        # Return paginated result
+        "Map<String, @Contextual Any?>"
+
+      action.type == :read ->
+        "List<#{resource_name}>"
+
+      action.type in [:create, :update] ->
+        "#{resource_name}"
+
+      true ->
+        "Map<String, @Contextual Any?>"
+    end
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/function_generators/http_renderer.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/function_generators/http_renderer.ex
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.FunctionGenerators.HttpRenderer do
+  @moduledoc """
+  Renders HTTP-specific Kotlin suspend functions (Ktor-based).
+
+  Takes the function "shape" from FunctionCore and renders it as
+  a Kotlin suspend function using Ktor HttpClient.
+  """
+
+  alias AshKotlinMultiplatform.Rpc.Codegen.FunctionGenerators.FunctionCore
+  alias AshKotlinMultiplatform.Rpc.Codegen.Helpers.{ConfigBuilder, PayloadBuilder}
+  alias AshIntrospection.Helpers
+
+  @doc """
+  Renders an HTTP execution function (suspend function with Ktor).
+  """
+  def render_execution_function(resource, action, rpc_action, rpc_action_name) do
+    shape =
+      FunctionCore.build_execution_function_shape(
+        resource,
+        action,
+        rpc_action,
+        rpc_action_name,
+        transport: :http
+      )
+
+    function_name = Helpers.snake_to_camel_case(rpc_action_name)
+    config_name = "#{shape.rpc_action_name_pascal}Config"
+    endpoint = AshKotlinMultiplatform.run_endpoint()
+
+    # Generate the config type
+    config_type =
+      ConfigBuilder.generate_config_type(resource, action, rpc_action, rpc_action_name)
+
+    # Generate payload construction code
+    payload_code =
+      PayloadBuilder.build_payload_code(
+        rpc_action_name,
+        shape.context,
+        include_fields: shape.has_fields,
+        include_metadata_fields: shape.has_metadata
+      )
+
+    """
+    #{config_type}
+    suspend fun #{function_name}(
+        client: HttpClient,
+        config: #{config_name},
+        endpoint: String = "#{endpoint}"
+    ): RpcResult<Map<String, Any?>> {
+        return client.post(endpoint) {
+            contentType(ContentType.Application.Json)
+            config.headers.forEach { (key, value) ->
+                header(key, value)
+            }
+            setBody(buildJsonObject {
+                #{payload_code}
+            })
+        }.body()
+    }
+    """
+  end
+
+  @doc """
+  Renders an HTTP validation function.
+  """
+  def render_validation_function(resource, action, rpc_action, rpc_action_name) do
+    shape =
+      FunctionCore.build_validation_function_shape(
+        resource,
+        action,
+        rpc_action,
+        rpc_action_name
+      )
+
+    function_name = "validate#{shape.rpc_action_name_pascal}"
+    endpoint = AshKotlinMultiplatform.validate_endpoint()
+
+    # Generate validation-specific config
+    config_type = generate_validation_config_type(shape)
+
+    # Generate payload construction code
+    payload_code = PayloadBuilder.build_validation_payload_code(rpc_action_name, shape.context)
+
+    """
+    #{config_type}
+    suspend fun #{function_name}(
+        client: HttpClient,
+        config: #{shape.rpc_action_name_pascal}ValidationConfig,
+        endpoint: String = "#{endpoint}"
+    ): ValidationResult {
+        return client.post(endpoint) {
+            contentType(ContentType.Application.Json)
+            config.headers.forEach { (key, value) ->
+                header(key, value)
+            }
+            setBody(buildJsonObject {
+                #{payload_code}
+            })
+        }.body()
+    }
+    """
+  end
+
+  defp generate_validation_config_type(shape) do
+    fields = []
+
+    # Add tenant if required
+    fields =
+      if shape.context.requires_tenant do
+        fields ++ ["    val tenant: String"]
+      else
+        fields
+      end
+
+    # Add input field based on input type
+    fields =
+      case shape.context.action_input_type do
+        :required ->
+          fields ++ ["    val input: #{shape.rpc_action_name_pascal}Input"]
+
+        :optional ->
+          fields ++ ["    val input: #{shape.rpc_action_name_pascal}Input? = null"]
+
+        :none ->
+          fields
+      end
+
+    # Add headers field
+    fields = fields ++ ["    val headers: Map<String, String> = emptyMap()"]
+
+    """
+    data class #{shape.rpc_action_name_pascal}ValidationConfig(
+    #{Enum.join(fields, ",\n")}
+    )
+    """
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/action_introspection.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/action_introspection.ex
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ActionIntrospection do
+  @moduledoc """
+  Introspection helpers for Ash actions used in Kotlin code generation.
+
+  This module provides functions to analyze action characteristics such as
+  pagination support, input requirements, and return types.
+  """
+
+  alias AshIntrospection.Codegen.ActionIntrospection, as: SharedIntrospection
+
+  # Delegate to shared introspection module from ash_introspection
+
+  @doc """
+  Checks if an action supports any form of pagination.
+  """
+  defdelegate action_supports_pagination?(action), to: SharedIntrospection
+
+  @doc """
+  Checks if an action supports offset pagination (limit/offset).
+  """
+  defdelegate action_supports_offset_pagination?(action), to: SharedIntrospection
+
+  @doc """
+  Checks if an action supports keyset pagination (before/after cursors).
+  """
+  defdelegate action_supports_keyset_pagination?(action), to: SharedIntrospection
+
+  @doc """
+  Checks if pagination is required for the action (not optional).
+  """
+  defdelegate action_requires_pagination?(action), to: SharedIntrospection
+
+  @doc """
+  Checks if the action supports counting results.
+  """
+  defdelegate action_supports_countable?(action), to: SharedIntrospection
+
+  @doc """
+  Determines the input type for an action.
+  Returns :required, :optional, or :none.
+  """
+  defdelegate action_input_type(resource, action), to: SharedIntrospection
+
+  @doc """
+  Gets the list of required input fields for an action.
+  """
+  defdelegate get_required_inputs(resource, action), to: SharedIntrospection
+
+  @doc """
+  Gets the list of optional input fields for an action.
+  """
+  defdelegate get_optional_inputs(resource, action), to: SharedIntrospection
+
+  @doc """
+  Checks if an action returns a field-selectable type.
+  Returns {:ok, type, value} or {:error, reason}.
+  """
+  defdelegate action_returns_field_selectable_type?(action), to: SharedIntrospection
+
+  @doc """
+  Checks if an action has a default limit set for pagination.
+  """
+  def action_has_default_limit?(action) do
+    case action.pagination do
+      nil -> false
+      %{default_limit: limit} when is_integer(limit) and limit > 0 -> true
+      _ -> false
+    end
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
+  @moduledoc """
+  Builds Kotlin configuration field definitions for RPC functions.
+
+  Configuration fields define the parameters that can be passed to RPC functions,
+  including tenant, primary key, input, pagination, filters, and metadata fields.
+  """
+
+  alias AshKotlinMultiplatform.Codegen.TypeMapper
+  alias AshKotlinMultiplatform.Rpc.Codegen.Helpers.ActionIntrospection
+  alias AshIntrospection.Helpers
+
+  @doc """
+  Gets the action context - a map of values indicating what features the action supports.
+
+  ## Parameters
+
+    * `resource` - The Ash resource
+    * `action` - The Ash action (possibly augmented with RPC settings)
+    * `rpc_action` - The RPC action configuration
+
+  ## Returns
+
+  A map with the following keys:
+  - `:requires_tenant` - Whether the action requires a tenant parameter
+  - `:identities` - List of identity atoms for record lookup (update/destroy actions)
+  - `:supports_pagination` - Whether the action supports pagination (list reads)
+  - `:supports_filtering` - Whether the action supports filtering (list reads)
+  - `:action_input_type` - Whether the input is :none, :required, or :optional
+  - `:is_get_action` - Whether this is a get action (returns single or null)
+  """
+  def get_action_context(resource, action, rpc_action) do
+    # Check both Ash's native get? and RPC's get?/get_by options
+    ash_get? = action.type == :read and Map.get(action, :get?, false)
+    rpc_get? = Map.get(rpc_action, :get?, false)
+    rpc_get_by = (Map.get(rpc_action, :get_by) || []) != []
+
+    is_get_action = ash_get? or rpc_get? or rpc_get_by
+
+    identities =
+      if action.type in [:update, :destroy] do
+        Map.get(rpc_action, :identities, [:_primary_key])
+      else
+        []
+      end
+
+    %{
+      requires_tenant: AshKotlinMultiplatform.requires_tenant_parameter?(resource),
+      identities: identities,
+      supports_pagination:
+        action.type == :read and not is_get_action and
+          ActionIntrospection.action_supports_pagination?(action),
+      supports_filtering: action.type == :read and not is_get_action,
+      action_input_type: ActionIntrospection.action_input_type(resource, action),
+      is_get_action: is_get_action
+    }
+  end
+
+  @doc """
+  Generates a Kotlin config data class for an RPC action.
+
+  ## Parameters
+
+    * `resource` - The Ash resource
+    * `action` - The Ash action
+    * `rpc_action` - The RPC action configuration
+    * `rpc_action_name` - The name of the RPC action
+
+  ## Returns
+
+  A string containing the Kotlin data class definition.
+  """
+  def generate_config_type(resource, action, rpc_action, rpc_action_name) do
+    rpc_action_name_pascal = Helpers.snake_to_pascal_case(rpc_action_name)
+    context = get_action_context(resource, action, rpc_action)
+
+    fields = []
+
+    # Add tenant field if required
+    fields =
+      if context.requires_tenant do
+        fields ++ [{:tenant, "String", false}]
+      else
+        fields
+      end
+
+    # Add identity field if needed for update/destroy
+    fields =
+      if context.identities != [] do
+        fields ++ [{:identity, build_identity_type(resource, context.identities), false}]
+      else
+        fields
+      end
+
+    # Add input field based on input type
+    fields =
+      case context.action_input_type do
+        :required ->
+          fields ++ [{:input, "#{rpc_action_name_pascal}Input", false}]
+
+        :optional ->
+          fields ++ [{:input, "#{rpc_action_name_pascal}Input?", true, "null"}]
+
+        :none ->
+          fields
+      end
+
+    # Add fields selection field for non-destroy actions
+    fields =
+      if action.type != :destroy do
+        fields ++ [{:fields, "List<Any>", true, "emptyList()"}]
+      else
+        fields
+      end
+
+    # Add filter and sort for list reads
+    fields =
+      if context.supports_filtering do
+        fields ++
+          [
+            {:filter, "Map<String, @Contextual Any?>?", true, "null"},
+            {:sort, "String?", true, "null"}
+          ]
+      else
+        fields
+      end
+
+    # Add pagination config for paginated reads
+    fields =
+      if context.supports_pagination do
+        fields ++ [{:page, "Map<String, @Contextual Any?>?", true, "null"}]
+      else
+        fields
+      end
+
+    # Add headers field
+    fields = fields ++ [{:headers, "Map<String, String>", true, "emptyMap()"}]
+
+    # Generate the data class
+    field_defs =
+      Enum.map(fields, fn
+        {name, type, true, default} ->
+          "    val #{Helpers.snake_to_camel_case(name)}: #{type} = #{default}"
+
+        {name, type, true} ->
+          "    val #{Helpers.snake_to_camel_case(name)}: #{type}? = null"
+
+        {name, type, false} ->
+          "    val #{Helpers.snake_to_camel_case(name)}: #{type}"
+      end)
+
+    """
+    data class #{rpc_action_name_pascal}Config(
+    #{Enum.join(field_defs, ",\n")}
+    )
+    """
+  end
+
+  @doc """
+  Builds the Kotlin type for an identity field.
+  """
+  def build_identity_type(resource, identities) do
+    # For simplicity, if there's only primary key identity, use the primary key type
+    # Otherwise, use a generic type
+    case identities do
+      [:_primary_key] ->
+        primary_key_attrs = Ash.Resource.Info.primary_key(resource)
+
+        if Enum.count(primary_key_attrs) == 1 do
+          attr_name = Enum.at(primary_key_attrs, 0)
+          attr = Ash.Resource.Info.attribute(resource, attr_name)
+          TypeMapper.get_kotlin_type_for_type(attr.type, attr.constraints || [])
+        else
+          # Composite primary key - use a Map
+          "Map<String, @Contextual Any>"
+        end
+
+      _ ->
+        # Multiple identities - use a generic type
+        "@Contextual Any"
+    end
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/payload_builder.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/payload_builder.ex
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.PayloadBuilder do
+  @moduledoc """
+  Builds RPC request payload structures for Kotlin code generation.
+
+  This module generates the payload construction code that will be used
+  in the generated Kotlin RPC functions to send requests to the server.
+  """
+
+
+  @doc """
+  Generates the payload construction code for an RPC function.
+
+  ## Parameters
+
+    * `rpc_action_name` - The name of the RPC action
+    * `context` - The action context from ConfigBuilder
+    * `opts` - Options keyword list:
+      - `:include_fields` - Whether to include the fields parameter
+      - `:include_metadata_fields` - Whether to include metadata_fields parameter
+
+  ## Returns
+
+  A string containing Kotlin code for building the request payload.
+  """
+  def build_payload_code(rpc_action_name, context, opts \\ []) do
+    include_fields = Keyword.get(opts, :include_fields, true)
+    include_metadata_fields = Keyword.get(opts, :include_metadata_fields, false)
+
+    payload_lines = [
+      "put(\"action\", \"#{rpc_action_name}\")"
+    ]
+
+    # Add tenant if required
+    payload_lines =
+      if context.requires_tenant do
+        payload_lines ++ ["put(\"tenant\", config.tenant)"]
+      else
+        payload_lines
+      end
+
+    # Add identity if present
+    payload_lines =
+      if context.identities != [] do
+        payload_lines ++ ["put(\"identity\", Json.encodeToJsonElement(config.identity))"]
+      else
+        payload_lines
+      end
+
+    # Add input if needed
+    payload_lines =
+      case context.action_input_type do
+        :required ->
+          payload_lines ++ ["put(\"input\", Json.encodeToJsonElement(config.input))"]
+
+        :optional ->
+          payload_lines ++ ["config.input?.let { put(\"input\", Json.encodeToJsonElement(it)) }"]
+
+        :none ->
+          payload_lines
+      end
+
+    # Add fields if included
+    payload_lines =
+      if include_fields do
+        payload_lines ++
+          [
+            """
+            putJsonArray("fields") {
+                            config.fields.forEach { field ->
+                                when (field) {
+                                    is String -> add(field)
+                                    else -> add(Json.encodeToJsonElement(field))
+                                }
+                            }
+                        }
+            """
+            |> String.trim()
+          ]
+      else
+        payload_lines
+      end
+
+    # Add filter if supported
+    payload_lines =
+      if context.supports_filtering do
+        payload_lines ++
+          [
+            "config.filter?.let { put(\"filter\", Json.encodeToJsonElement(it)) }",
+            "config.sort?.let { put(\"sort\", it) }"
+          ]
+      else
+        payload_lines
+      end
+
+    # Add pagination if supported
+    payload_lines =
+      if context.supports_pagination do
+        payload_lines ++ ["config.page?.let { put(\"page\", Json.encodeToJsonElement(it)) }"]
+      else
+        payload_lines
+      end
+
+    # Add metadata fields if included
+    payload_lines =
+      if include_metadata_fields do
+        payload_lines ++
+          ["config.metadataFields?.let { put(\"metadataFields\", Json.encodeToJsonElement(it)) }"]
+      else
+        payload_lines
+      end
+
+    Enum.join(payload_lines, "\n                ")
+  end
+
+  @doc """
+  Generates the payload for a validation request.
+  """
+  def build_validation_payload_code(rpc_action_name, context) do
+    payload_lines = [
+      "put(\"action\", \"#{rpc_action_name}\")"
+    ]
+
+    # Add tenant if required
+    payload_lines =
+      if context.requires_tenant do
+        payload_lines ++ ["put(\"tenant\", config.tenant)"]
+      else
+        payload_lines
+      end
+
+    # Add input if needed
+    payload_lines =
+      case context.action_input_type do
+        :required ->
+          payload_lines ++ ["put(\"input\", Json.encodeToJsonElement(config.input))"]
+
+        :optional ->
+          payload_lines ++ ["config.input?.let { put(\"input\", Json.encodeToJsonElement(it)) }"]
+
+        :none ->
+          payload_lines
+      end
+
+    Enum.join(payload_lines, "\n                ")
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
+  @moduledoc """
+  Generates static Kotlin code components that are included in every generated file.
+
+  This includes imports, utility types, error types, and helper functions.
+  """
+
+  @doc """
+  Generates the standard imports for the generated Kotlin file.
+  """
+  def generate_imports(opts \\ []) do
+    datetime_imports =
+      case AshKotlinMultiplatform.datetime_library() do
+        :kotlinx_datetime -> "import kotlinx.datetime.*"
+        :java_time -> "import java.time.*"
+      end
+
+    websocket_imports =
+      if AshKotlinMultiplatform.generate_phoenix_channel_client?() do
+        """
+        import io.ktor.client.plugins.websocket.*
+        import io.ktor.websocket.*
+        import kotlinx.coroutines.*
+        """
+      else
+        ""
+      end
+
+    validation_imports =
+      if Keyword.get(opts, :with_validation, false) do
+        """
+        import javax.validation.constraints.*
+        """
+      else
+        ""
+      end
+
+    """
+    import kotlinx.serialization.*
+    import kotlinx.serialization.json.*
+    #{datetime_imports}
+    import io.ktor.client.*
+    import io.ktor.client.call.*
+    import io.ktor.client.request.*
+    import io.ktor.http.*
+    #{websocket_imports}#{validation_imports}
+    """
+    |> String.trim()
+  end
+
+  @doc """
+  Generates type aliases for common types.
+  """
+  def generate_type_aliases do
+    """
+    // Type aliases for common types
+    typealias UUID = String
+    typealias Decimal = String
+    """
+  end
+
+  @doc """
+  Generates the RPC error types.
+  """
+  def generate_error_types do
+    """
+    // RPC Error types
+    @Serializable
+    data class AshRpcError(
+        val type: String,
+        val message: String,
+        @SerialName("short_message")
+        val shortMessage: String,
+        val vars: Map<String, String> = emptyMap(),
+        val fields: List<String> = emptyList(),
+        val path: List<String> = emptyList(),
+        val details: Map<String, @Contextual Any?>? = null
+    )
+    """
+  end
+
+  @doc """
+  Generates the generic RPC result types.
+  """
+  def generate_generic_result_types do
+    """
+    // Generic result wrapper
+    @Serializable
+    sealed class RpcResult<T> {
+        abstract val success: Boolean
+    }
+
+    @Serializable
+    @SerialName("success")
+    data class RpcSuccess<T>(
+        override val success: Boolean = true,
+        val data: T,
+        val metadata: Map<String, @Contextual Any?>? = null
+    ) : RpcResult<T>()
+
+    @Serializable
+    @SerialName("error")
+    data class RpcError<T>(
+        override val success: Boolean = false,
+        val errors: List<AshRpcError>
+    ) : RpcResult<T>()
+    """
+  end
+
+  @doc """
+  Generates the validation result type.
+  """
+  def generate_validation_types do
+    """
+    // Validation result types
+    @Serializable
+    sealed class ValidationResult {
+        abstract val valid: Boolean
+    }
+
+    @Serializable
+    @SerialName("valid")
+    data class ValidationValid(
+        override val valid: Boolean = true
+    ) : ValidationResult()
+
+    @Serializable
+    @SerialName("invalid")
+    data class ValidationInvalid(
+        override val valid: Boolean = false,
+        val errors: List<AshRpcError>
+    ) : ValidationResult()
+    """
+  end
+
+  @doc """
+  Generates lifecycle hook type definitions if hooks are enabled.
+  """
+  def generate_hook_types do
+    before_request = AshKotlinMultiplatform.rpc_action_before_request_hook()
+    after_request = AshKotlinMultiplatform.rpc_action_after_request_hook()
+
+    if before_request || after_request do
+      """
+      // Hook context types
+      data class ActionHookContext(
+          val action: String,
+          val input: Map<String, Any?>? = null,
+          val metadata: Map<String, Any?>? = null
+      )
+      """
+    else
+      ""
+    end
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/rpc_config_collector.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/rpc_config_collector.ex
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.RpcConfigCollector do
+  @moduledoc """
+  Collects RPC configuration from domains including resources, actions, and typed queries.
+  """
+
+  alias AshKotlinMultiplatform.Rpc.Info
+
+  @doc """
+  Gets all RPC resources and their actions from an OTP application.
+
+  Returns a list of tuples: `{resource, action, rpc_action}`
+  """
+  def get_rpc_resources_and_actions(otp_app) do
+    otp_app
+    |> Ash.Info.domains()
+    |> Enum.flat_map(fn domain ->
+      rpc_config = Info.kotlin_rpc(domain)
+
+      Enum.flat_map(rpc_config, fn %{resource: resource, rpc_actions: rpc_actions} ->
+        Enum.map(rpc_actions, fn rpc_action ->
+          action = Ash.Resource.Info.action(resource, rpc_action.action)
+          {resource, action, rpc_action}
+        end)
+      end)
+    end)
+  end
+
+  @doc """
+  Gets all typed queries from an OTP application.
+
+  Returns a list of tuples: `{resource, action, typed_query}`
+  """
+  def get_typed_queries(otp_app) do
+    otp_app
+    |> Ash.Info.domains()
+    |> Enum.flat_map(fn domain ->
+      rpc_config = Info.kotlin_rpc(domain)
+
+      Enum.flat_map(rpc_config, fn %{resource: resource, typed_queries: typed_queries} ->
+        Enum.map(typed_queries, fn typed_query ->
+          action = Ash.Resource.Info.action(resource, typed_query.action)
+          {resource, action, typed_query}
+        end)
+      end)
+    end)
+  end
+
+  @doc """
+  Gets all RPC-configured resources from an OTP application.
+
+  Returns a list of unique resource modules.
+  """
+  def get_rpc_resources(otp_app) do
+    otp_app
+    |> Ash.Info.domains()
+    |> Enum.flat_map(fn domain ->
+      Info.kotlin_rpc(domain)
+      |> Enum.map(fn %{resource: r} -> r end)
+    end)
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Gets all RPC configurations grouped by resource.
+
+  Returns a list of maps with resource and their actions/queries.
+  """
+  def get_rpc_configs(otp_app) do
+    otp_app
+    |> Ash.Info.domains()
+    |> Enum.flat_map(&Info.kotlin_rpc/1)
+  end
+
+  @doc """
+  Gets all domains that have RPC configuration.
+  """
+  def get_rpc_domains(otp_app) do
+    otp_app
+    |> Ash.Info.domains()
+    |> Enum.filter(fn domain ->
+      case Info.kotlin_rpc(domain) do
+        [] -> false
+        _ -> true
+      end
+    end)
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.MetadataTypes do
+  @moduledoc """
+  Generates Kotlin metadata types for RPC actions.
+
+  Metadata types define the shape of metadata that can be returned from RPC actions.
+  Actions can expose specific metadata fields via the `show_metadata` option.
+  """
+
+  alias AshKotlinMultiplatform.Codegen.TypeMapper
+  alias AshIntrospection.Helpers
+
+  @doc """
+  Gets the list of metadata fields that should be exposed for an RPC action.
+
+  ## Parameters
+
+    * `rpc_action` - The RPC action configuration
+    * `ash_action` - The underlying Ash action
+
+  ## Returns
+
+  A list of metadata field names (atoms) that should be exposed.
+
+  ## Examples
+
+      # No metadata override - expose all metadata fields
+      iex> get_exposed_metadata_fields(%{}, %{metadata: [%{name: :total_count}]})
+      [:total_count]
+
+      # Empty list - expose no metadata fields
+      iex> get_exposed_metadata_fields(%{show_metadata: []}, %{metadata: [%{name: :total_count}]})
+      []
+
+      # Specific fields - expose only listed fields
+      iex> get_exposed_metadata_fields(%{show_metadata: [:total_count]}, %{metadata: [...]})
+      [:total_count]
+  """
+  def get_exposed_metadata_fields(rpc_action, ash_action) do
+    show_metadata = Map.get(rpc_action, :show_metadata, nil)
+
+    case show_metadata do
+      nil -> Enum.map(Map.get(ash_action, :metadata, []), & &1.name)
+      false -> []
+      [] -> []
+      field_list when is_list(field_list) -> field_list
+    end
+  end
+
+  @doc """
+  Checks if metadata is enabled for an action based on exposed fields.
+
+  ## Parameters
+
+    * `exposed_fields` - List of metadata fields that are exposed
+
+  ## Returns
+
+  Boolean indicating if metadata is enabled (has at least one exposed field).
+  """
+  def metadata_enabled?(exposed_fields) do
+    not Enum.empty?(exposed_fields)
+  end
+
+  @doc """
+  Generates the Kotlin metadata data class for an RPC action.
+
+  Returns an empty string if no metadata fields are exposed.
+
+  ## Parameters
+
+    * `action` - The Ash action
+    * `rpc_action` - The RPC action configuration
+    * `rpc_action_name` - The name of the RPC action
+
+  ## Returns
+
+  A string containing the Kotlin metadata type definition, or an empty string if no metadata is exposed.
+  """
+  def generate_action_metadata_type(action, rpc_action, rpc_action_name) do
+    exposed_fields = get_exposed_metadata_fields(rpc_action, action)
+    rpc_action_name_pascal = Helpers.snake_to_pascal_case(rpc_action_name)
+
+    if metadata_enabled?(exposed_fields) do
+      all_metadata_fields = Map.get(action, :metadata, [])
+
+      metadata_fields_to_include =
+        Enum.filter(all_metadata_fields, fn metadata_field ->
+          metadata_field.name in exposed_fields
+        end)
+
+      metadata_field_defs =
+        Enum.map(metadata_fields_to_include, fn metadata_field ->
+          kotlin_type = TypeMapper.get_kotlin_type_for_type(metadata_field.type, metadata_field.constraints || [])
+
+          optional = Map.get(metadata_field, :allow_nil?, true)
+
+          # Check for mapped metadata field names
+          metadata_field_names = Map.get(rpc_action, :metadata_field_names, [])
+          mapped_name = Keyword.get(metadata_field_names, metadata_field.name, metadata_field.name)
+          formatted_name = Helpers.snake_to_camel_case(mapped_name)
+
+          # Add @SerialName if the formatted name differs from the original
+          serial_name_annotation =
+            if to_string(mapped_name) != to_string(metadata_field.name) do
+              "    @SerialName(\"#{metadata_field.name}\")\n"
+            else
+              ""
+            end
+
+          if optional do
+            "#{serial_name_annotation}    val #{formatted_name}: #{kotlin_type}? = null"
+          else
+            "#{serial_name_annotation}    val #{formatted_name}: #{kotlin_type}"
+          end
+        end)
+
+      """
+      @Serializable
+      data class #{rpc_action_name_pascal}Metadata(
+      #{Enum.join(metadata_field_defs, ",\n")}
+      )
+      """
+    else
+      ""
+    end
+  end
+
+  @doc """
+  Checks if an action has any metadata that can be exposed.
+  """
+  def action_has_metadata?(action) do
+    case Map.get(action, :metadata, []) do
+      [] -> false
+      _ -> true
+    end
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/pagination_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/pagination_types.ex
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.PaginationTypes do
+  @moduledoc """
+  Generates Kotlin pagination result types for RPC actions.
+
+  Supports:
+  - Offset pagination (limit/offset)
+  - Keyset pagination (limit/after/before)
+  - Mixed pagination (both offset and keyset)
+  """
+
+  alias AshIntrospection.Codegen.ActionIntrospection
+  alias AshIntrospection.Helpers
+
+  @doc """
+  Generates the pagination result type based on the action's pagination support.
+
+  ## Parameters
+
+    * `resource` - The Ash resource
+    * `action` - The Ash action
+    * `rpc_action_name` - The name of the RPC action
+    * `resource_name` - The Kotlin resource type name
+    * `has_metadata` - Boolean indicating if metadata is enabled
+
+  ## Returns
+
+  A string containing the Kotlin result type definition for the appropriate pagination type.
+  """
+  def generate_pagination_result_type(
+        _resource,
+        action,
+        rpc_action_name,
+        resource_name,
+        has_metadata
+      ) do
+    supports_offset = ActionIntrospection.action_supports_offset_pagination?(action)
+    supports_keyset = ActionIntrospection.action_supports_keyset_pagination?(action)
+    rpc_action_name_pascal = Helpers.snake_to_pascal_case(rpc_action_name)
+
+    cond do
+      supports_offset and supports_keyset ->
+        generate_mixed_pagination_result_type(
+          rpc_action_name_pascal,
+          resource_name,
+          has_metadata
+        )
+
+      supports_offset ->
+        generate_offset_pagination_result_type(
+          rpc_action_name_pascal,
+          resource_name,
+          has_metadata
+        )
+
+      supports_keyset ->
+        generate_keyset_pagination_result_type(
+          rpc_action_name_pascal,
+          resource_name,
+          has_metadata
+        )
+
+      true ->
+        ""
+    end
+  end
+
+  @doc """
+  Generates an offset pagination result data class.
+
+  The result includes:
+  - results: List of items
+  - hasMore: Boolean indicating if more results exist
+  - limit: Number of items per page
+  - offset: Current offset
+  - count: Optional total count
+  """
+  def generate_offset_pagination_result_type(rpc_action_name_pascal, resource_name, _has_metadata) do
+    """
+    @Serializable
+    data class #{rpc_action_name_pascal}OffsetResult(
+        val results: List<#{resource_name}>,
+        val hasMore: Boolean,
+        val limit: Int,
+        val offset: Int,
+        val count: Int? = null
+    )
+    """
+  end
+
+  @doc """
+  Generates a keyset pagination result data class.
+
+  The result includes:
+  - results: List of items
+  - hasMore: Boolean indicating if more results exist
+  - limit: Number of items per page
+  - after: Cursor for next page (or null)
+  - before: Cursor for previous page (or null)
+  - previousPage: Cursor string for previous page
+  - nextPage: Cursor string for next page
+  - count: Optional total count
+  """
+  def generate_keyset_pagination_result_type(rpc_action_name_pascal, resource_name, _has_metadata) do
+    """
+    @Serializable
+    data class #{rpc_action_name_pascal}KeysetResult(
+        val results: List<#{resource_name}>,
+        val hasMore: Boolean,
+        val limit: Int,
+        @SerialName("after")
+        val afterCursor: String? = null,
+        @SerialName("before")
+        val beforeCursor: String? = null,
+        val previousPage: String = "",
+        val nextPage: String = "",
+        val count: Int? = null
+    )
+    """
+  end
+
+  @doc """
+  Generates a mixed pagination sealed class (supports both offset and keyset).
+
+  Uses sealed class hierarchy to discriminate between offset and keyset results.
+  """
+  def generate_mixed_pagination_result_type(rpc_action_name_pascal, resource_name, _has_metadata) do
+    """
+    @Serializable
+    sealed class #{rpc_action_name_pascal}PaginatedResult {
+        abstract val results: List<#{resource_name}>
+        abstract val hasMore: Boolean
+        abstract val limit: Int
+        abstract val count: Int?
+    }
+
+    @Serializable
+    @SerialName("offset")
+    data class #{rpc_action_name_pascal}OffsetPaginatedResult(
+        override val results: List<#{resource_name}>,
+        override val hasMore: Boolean,
+        override val limit: Int,
+        override val count: Int? = null,
+        val offset: Int
+    ) : #{rpc_action_name_pascal}PaginatedResult()
+
+    @Serializable
+    @SerialName("keyset")
+    data class #{rpc_action_name_pascal}KeysetPaginatedResult(
+        override val results: List<#{resource_name}>,
+        override val hasMore: Boolean,
+        override val limit: Int,
+        override val count: Int? = null,
+        @SerialName("after")
+        val afterCursor: String? = null,
+        @SerialName("before")
+        val beforeCursor: String? = null,
+        val previousPage: String = "",
+        val nextPage: String = ""
+    ) : #{rpc_action_name_pascal}PaginatedResult()
+    """
+  end
+
+  @doc """
+  Generates pagination config types for request configuration.
+  """
+  def generate_pagination_config_types do
+    """
+    // Pagination config types
+    @Serializable
+    data class OffsetPaginationConfig(
+        val limit: Int? = null,
+        val offset: Int? = null,
+        val count: Boolean = false
+    )
+
+    @Serializable
+    data class KeysetPaginationConfig(
+        val limit: Int? = null,
+        val after: String? = null,
+        val before: String? = null,
+        val count: Boolean = false
+    )
+    """
+  end
+
+  @doc """
+  Checks if an action supports any form of pagination.
+  """
+  def action_supports_pagination?(action) do
+    ActionIntrospection.action_supports_pagination?(action)
+  end
+
+  @doc """
+  Checks if an action requires pagination (not optional).
+  """
+  def action_requires_pagination?(action) do
+    ActionIntrospection.action_requires_pagination?(action)
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_action_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_action_types.ex
@@ -1,0 +1,544 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyActionTypes do
+  @moduledoc """
+  Verifies that field names in action return types and argument types are valid for Kotlin.
+
+  For each exposed RPC action, this verifier checks:
+  1. Return type field names (for generic actions with `:action` type)
+  2. Argument type field names (for all action types)
+
+  This ensures that map, keyword, tuple, struct, embedded resource, and union types
+  used in action signatures have valid Kotlin-compatible field names.
+  """
+  use Spark.Dsl.Verifier
+  alias AshIntrospection.TypeSystem.Introspection
+  alias Spark.Dsl.Verifier
+
+  # Suppress dialyzer warnings about MapSet opaque type
+  @dialyzer {:nowarn_function, validate_unwrapped_type: 5}
+  @dialyzer {:nowarn_function, validate_type_field_names: 5}
+  @dialyzer {:nowarn_function, validate_struct_type: 4}
+  @dialyzer {:nowarn_function, validate_typed_struct_fields: 4}
+  @dialyzer {:nowarn_function, validate_new_type_fields: 4}
+  @dialyzer {:nowarn_function, validate_embedded_resource: 4}
+  @dialyzer {:nowarn_function, validate_resource_fields: 4}
+  @dialyzer {:nowarn_function, validate_composite_type: 5}
+
+  @impl true
+  def verify(dsl) do
+    dsl
+    |> Verifier.get_entities([:kotlin_rpc])
+    |> Enum.flat_map(fn %{resource: resource, rpc_actions: rpc_actions} ->
+      validate_rpc_actions(resource, rpc_actions)
+    end)
+    |> case do
+      [] -> :ok
+      errors -> format_validation_errors(errors)
+    end
+  end
+
+  defp validate_rpc_actions(resource, rpc_actions) do
+    Enum.flat_map(rpc_actions, fn rpc_action ->
+      action = Ash.Resource.Info.action(resource, rpc_action.action)
+
+      if action do
+        return_type_errors = validate_return_type(resource, rpc_action, action)
+        argument_type_errors = validate_argument_types(resource, rpc_action, action)
+        return_type_errors ++ argument_type_errors
+      else
+        []
+      end
+    end)
+  end
+
+  # Validate return types for generic actions
+  defp validate_return_type(resource, rpc_action, %{type: :action} = action) do
+    case action.returns do
+      nil ->
+        []
+
+      returns ->
+        constraints = Map.get(action, :constraints, [])
+
+        validate_type_field_names(
+          resource,
+          returns,
+          constraints,
+          {:return_type, rpc_action.name, action.name}
+        )
+    end
+  end
+
+  # CRUD actions return the resource itself, which is already validated by resource verifiers
+  defp validate_return_type(_resource, _rpc_action, _action), do: []
+
+  # Validate argument types for all actions
+  defp validate_argument_types(resource, rpc_action, action) do
+    action.arguments
+    |> Enum.filter(& &1.public?)
+    |> Enum.flat_map(fn argument ->
+      validate_type_field_names(
+        resource,
+        argument.type,
+        argument.constraints,
+        {:argument, rpc_action.name, action.name, argument.name}
+      )
+    end)
+  end
+
+  # Type validation - handles various Ash types with field constraints
+  defp validate_type_field_names(resource, type, constraints, context, visited \\ MapSet.new()) do
+    # Handle array types
+    {inner_type, inner_constraints} = unwrap_array_type(type, constraints)
+
+    # Unwrap NewType if applicable
+    {unwrapped_type, unwrapped_constraints} =
+      Introspection.unwrap_new_type(inner_type, inner_constraints, :interop_field_names)
+
+    validate_unwrapped_type(resource, unwrapped_type, unwrapped_constraints, context, visited)
+  end
+
+  defp unwrap_array_type({:array, inner_type}, constraints) do
+    items_constraints = Keyword.get(constraints, :items, [])
+    {inner_type, items_constraints}
+  end
+
+  defp unwrap_array_type(type, constraints), do: {type, constraints}
+
+  defp validate_unwrapped_type(resource, type, constraints, context, visited) do
+    cond do
+      # Map, Keyword, or Tuple types with field constraints
+      type in [Ash.Type.Map, Ash.Type.Keyword, Ash.Type.Tuple] ->
+        validate_fields_constraint(resource, constraints, context, visited)
+
+      # Union types - check each union member
+      type == Ash.Type.Union ->
+        validate_union_types(resource, constraints, context, visited)
+
+      # Struct types - check if typed struct with fields
+      type == Ash.Type.Struct ->
+        validate_struct_type(resource, constraints, context, visited)
+
+      # Embedded resources - check public fields (skip if already visited)
+      Introspection.is_embedded_resource?(type) ->
+        if MapSet.member?(visited, type) do
+          []
+        else
+          validate_embedded_resource(resource, type, context, MapSet.put(visited, type))
+        end
+
+      # Regular Ash resources - check public fields (skip if already visited)
+      is_atom(type) and Ash.Resource.Info.resource?(type) ->
+        if MapSet.member?(visited, type) do
+          []
+        else
+          validate_resource_fields(resource, type, context, MapSet.put(visited, type))
+        end
+
+      # Custom Ash.Type with composite types (skip if already visited)
+      is_atom(type) and is_composite_type?(type, constraints) ->
+        if MapSet.member?(visited, type) do
+          []
+        else
+          validate_composite_type(resource, type, constraints, context, MapSet.put(visited, type))
+        end
+
+      # Primitives and other types - no field validation needed
+      true ->
+        []
+    end
+  end
+
+  defp validate_fields_constraint(resource, constraints, context, visited) do
+    case Keyword.get(constraints, :fields) do
+      nil ->
+        []
+
+      fields ->
+        # Check if there's a field_names mapping from instance_of
+        field_name_mappings = get_field_name_mappings(constraints)
+
+        Enum.flat_map(fields, fn {field_name, field_config} ->
+          # Check if field name is mapped
+          mapped_name = Map.get(field_name_mappings, field_name, field_name)
+
+          # Check if the mapped field name is invalid
+          name_errors =
+            if invalid_name?(mapped_name) do
+              [{resource, context, :field, field_name, make_name_better(field_name)}]
+            else
+              []
+            end
+
+          # Recursively check nested types
+          field_type = Keyword.get(field_config, :type)
+          field_constraints = Keyword.get(field_config, :constraints, [])
+
+          nested_errors =
+            if field_type do
+              validate_type_field_names(resource, field_type, field_constraints, context, visited)
+            else
+              []
+            end
+
+          name_errors ++ nested_errors
+        end)
+    end
+  end
+
+  defp validate_union_types(resource, constraints, context, visited) do
+    case Keyword.get(constraints, :types) do
+      nil ->
+        []
+
+      types ->
+        Enum.flat_map(types, fn {_type_name, type_config} ->
+          type = Keyword.get(type_config, :type)
+          type_constraints = Keyword.get(type_config, :constraints, [])
+          validate_type_field_names(resource, type, type_constraints, context, visited)
+        end)
+    end
+  end
+
+  defp validate_struct_type(resource, constraints, context, visited) do
+    case Keyword.get(constraints, :instance_of) do
+      nil ->
+        validate_fields_constraint(resource, constraints, context, visited)
+
+      struct_module when is_atom(struct_module) ->
+        cond do
+          Ash.Resource.Info.resource?(struct_module) ->
+            if MapSet.member?(visited, struct_module) do
+              []
+            else
+              validate_resource_fields(
+                resource,
+                struct_module,
+                context,
+                MapSet.put(visited, struct_module)
+              )
+            end
+
+          function_exported?(struct_module, :typed_struct_fields, 0) ->
+            if MapSet.member?(visited, struct_module) do
+              []
+            else
+              validate_typed_struct_fields(
+                resource,
+                struct_module,
+                context,
+                MapSet.put(visited, struct_module)
+              )
+            end
+
+          Ash.Type.NewType.new_type?(struct_module) ->
+            if MapSet.member?(visited, struct_module) do
+              []
+            else
+              validate_new_type_fields(
+                resource,
+                struct_module,
+                context,
+                MapSet.put(visited, struct_module)
+              )
+            end
+
+          true ->
+            []
+        end
+    end
+  end
+
+  defp validate_typed_struct_fields(resource, struct_module, context, visited) do
+    field_name_mappings = get_typed_struct_mappings(struct_module)
+
+    struct_module.typed_struct_fields()
+    |> Enum.flat_map(fn {field_name, field_opts} ->
+      mapped_name = Map.get(field_name_mappings, field_name, field_name)
+
+      name_errors =
+        if invalid_name?(mapped_name) do
+          [{resource, context, :typed_struct_field, field_name, make_name_better(field_name)}]
+        else
+          []
+        end
+
+      field_type = Keyword.get(field_opts, :type)
+      field_constraints = Keyword.get(field_opts, :constraints, [])
+
+      nested_errors =
+        if field_type do
+          validate_type_field_names(resource, field_type, field_constraints, context, visited)
+        else
+          []
+        end
+
+      name_errors ++ nested_errors
+    end)
+  end
+
+  defp validate_new_type_fields(resource, new_type_module, context, visited) do
+    {_unwrapped_type, unwrapped_constraints} =
+      Introspection.unwrap_new_type(new_type_module, [], :interop_field_names)
+
+    field_name_mappings = get_typed_struct_mappings(new_type_module)
+
+    case Keyword.get(unwrapped_constraints, :fields) do
+      nil ->
+        []
+
+      fields ->
+        Enum.flat_map(fields, fn {field_name, field_config} ->
+          mapped_name = Map.get(field_name_mappings, field_name, field_name)
+
+          name_errors =
+            if invalid_name?(mapped_name) do
+              [{resource, context, :struct_field, field_name, make_name_better(field_name)}]
+            else
+              []
+            end
+
+          field_type = Keyword.get(field_config, :type)
+          field_constraints = Keyword.get(field_config, :constraints, [])
+
+          nested_errors =
+            if field_type do
+              validate_type_field_names(resource, field_type, field_constraints, context, visited)
+            else
+              []
+            end
+
+          name_errors ++ nested_errors
+        end)
+    end
+  end
+
+  defp validate_embedded_resource(resource, embedded_module, context, visited) do
+    field_name_mappings = get_resource_field_mappings(embedded_module)
+
+    attributes = Ash.Resource.Info.public_attributes(embedded_module)
+    calculations = Ash.Resource.Info.public_calculations(embedded_module)
+    aggregates = Ash.Resource.Info.public_aggregates(embedded_module)
+    relationships = Ash.Resource.Info.public_relationships(embedded_module)
+
+    attr_and_calc_errors =
+      (attributes ++ calculations)
+      |> Enum.flat_map(fn field ->
+        mapped_name = Map.get(field_name_mappings, field.name, field.name)
+
+        name_errors =
+          if invalid_name?(mapped_name) do
+            [{resource, context, :embedded_field, field.name, make_name_better(field.name)}]
+          else
+            []
+          end
+
+        nested_errors =
+          validate_type_field_names(resource, field.type, field.constraints, context, visited)
+
+        name_errors ++ nested_errors
+      end)
+
+    other_field_errors =
+      (aggregates ++ relationships)
+      |> Enum.flat_map(fn field ->
+        mapped_name = Map.get(field_name_mappings, field.name, field.name)
+
+        if invalid_name?(mapped_name) do
+          [{resource, context, :embedded_field, field.name, make_name_better(field.name)}]
+        else
+          []
+        end
+      end)
+
+    attr_and_calc_errors ++ other_field_errors
+  end
+
+  defp validate_resource_fields(resource, target_resource, context, visited) do
+    field_name_mappings = get_resource_field_mappings(target_resource)
+
+    attributes = Ash.Resource.Info.public_attributes(target_resource)
+    calculations = Ash.Resource.Info.public_calculations(target_resource)
+    aggregates = Ash.Resource.Info.public_aggregates(target_resource)
+    relationships = Ash.Resource.Info.public_relationships(target_resource)
+
+    attr_and_calc_errors =
+      (attributes ++ calculations)
+      |> Enum.flat_map(fn field ->
+        mapped_name = Map.get(field_name_mappings, field.name, field.name)
+
+        name_errors =
+          if invalid_name?(mapped_name) do
+            [{resource, context, :resource_field, field.name, make_name_better(field.name)}]
+          else
+            []
+          end
+
+        nested_errors =
+          validate_type_field_names(resource, field.type, field.constraints, context, visited)
+
+        name_errors ++ nested_errors
+      end)
+
+    other_field_errors =
+      (aggregates ++ relationships)
+      |> Enum.flat_map(fn field ->
+        mapped_name = Map.get(field_name_mappings, field.name, field.name)
+
+        if invalid_name?(mapped_name) do
+          [{resource, context, :resource_field, field.name, make_name_better(field.name)}]
+        else
+          []
+        end
+      end)
+
+    attr_and_calc_errors ++ other_field_errors
+  end
+
+  defp is_composite_type?(type, constraints) when is_atom(type) do
+    function_exported?(type, :composite?, 1) and type.composite?(constraints)
+  rescue
+    _ -> false
+  end
+
+  defp is_composite_type?(_, _), do: false
+
+  defp validate_composite_type(resource, type, constraints, context, visited) do
+    composite_fields =
+      if function_exported?(type, :composite_types, 1) do
+        type.composite_types(constraints)
+      else
+        []
+      end
+
+    field_name_mappings = get_typed_struct_mappings(type)
+
+    Enum.flat_map(composite_fields, fn field_def ->
+      {field_name, field_type, field_constraints} =
+        case field_def do
+          {name, storage_key, field_type, field_constraints} when is_atom(storage_key) ->
+            {name, field_type, field_constraints}
+
+          {name, field_type, field_constraints} ->
+            {name, field_type, field_constraints}
+        end
+
+      mapped_name = Map.get(field_name_mappings, field_name, field_name)
+
+      name_errors =
+        if invalid_name?(mapped_name) do
+          [{resource, context, :composite_field, field_name, make_name_better(field_name)}]
+        else
+          []
+        end
+
+      nested_errors =
+        if field_type do
+          validate_type_field_names(resource, field_type, field_constraints, context, visited)
+        else
+          []
+        end
+
+      name_errors ++ nested_errors
+    end)
+  end
+
+  # Helper functions for getting field name mappings
+
+  defp get_field_name_mappings(constraints) do
+    case Keyword.get(constraints, :instance_of) do
+      nil ->
+        %{}
+
+      module when is_atom(module) ->
+        if function_exported?(module, :interop_field_names, 0) do
+          module.interop_field_names() |> Map.new()
+        else
+          %{}
+        end
+    end
+  end
+
+  defp get_typed_struct_mappings(struct_module) do
+    if function_exported?(struct_module, :interop_field_names, 0) do
+      struct_module.interop_field_names() |> Map.new()
+    else
+      %{}
+    end
+  end
+
+  defp get_resource_field_mappings(resource_module) do
+    if AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_resource?(resource_module) do
+      field_names =
+        AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_field_names!(resource_module)
+
+      Map.new(field_names)
+    else
+      %{}
+    end
+  end
+
+  @doc false
+  def invalid_name?(name) do
+    Regex.match?(~r/_+\d|\?/, to_string(name))
+  end
+
+  @doc false
+  def make_name_better(name) do
+    name
+    |> to_string()
+    |> String.replace(~r/_+\d/, fn v ->
+      String.trim_leading(v, "_")
+    end)
+    |> String.replace("?", "")
+  end
+
+  defp format_validation_errors(errors) do
+    grouped_errors =
+      errors
+      |> Enum.group_by(fn {_resource, context, _field_type, _field_name, _suggested} ->
+        context
+      end)
+
+    message_parts = Enum.map_join(grouped_errors, "\n\n", &format_error_group/1)
+
+    {:error,
+     Spark.Error.DslError.exception(
+       message: """
+       Invalid field names found in action return types or argument types.
+       These patterns are not allowed in Kotlin code generation.
+
+       #{message_parts}
+
+       To fix this:
+       - For map/keyword/tuple types: Create a custom Ash.Type.NewType and define the `interop_field_names/0` callback
+       - For typed structs: Define the `interop_field_names/0` callback on the struct module
+       - For custom composite types: Define the `interop_field_names/0` callback on the custom type module
+       - For embedded resources: Use the `field_names` option in the resource's kotlin_multiplatform DSL block
+       - For action arguments: Use the `argument_names` option in the resource's kotlin_multiplatform DSL block
+       """
+     )}
+  end
+
+  defp format_error_group({context, errors}) do
+    context_description = format_context(context)
+
+    field_suggestions =
+      Enum.map_join(errors, "\n", fn {_resource, _context, field_type, field_name, suggested} ->
+        "    - #{field_type} #{field_name} -> #{suggested}"
+      end)
+
+    "#{context_description}:\n#{field_suggestions}"
+  end
+
+  defp format_context({:return_type, rpc_name, action_name}) do
+    "Invalid field names in return type of RPC action #{rpc_name} (action: #{action_name})"
+  end
+
+  defp format_context({:argument, rpc_name, action_name, arg_name}) do
+    "Invalid field names in argument #{arg_name} of RPC action #{rpc_name} (action: #{action_name})"
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
+  @moduledoc """
+  Verifies that all identities listed in RPC actions actually exist on the resource.
+
+  This catches configuration errors at compile time where an RPC action references
+  an identity that doesn't exist on the resource.
+  """
+  use Spark.Dsl.Verifier
+  alias Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl) do
+    dsl
+    |> Verifier.get_entities([:kotlin_rpc])
+    |> Enum.reduce_while(:ok, fn %{resource: resource, rpc_actions: rpc_actions}, acc ->
+      case verify_identities(resource, rpc_actions) do
+        :ok -> {:cont, acc}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp verify_identities(resource, rpc_actions) do
+    errors =
+      Enum.reduce(rpc_actions, [], fn rpc_action, acc ->
+        validate_rpc_action_identities(resource, rpc_action, acc)
+      end)
+
+    case errors do
+      [] -> :ok
+      _ -> format_identity_validation_errors(errors)
+    end
+  end
+
+  defp validate_rpc_action_identities(resource, rpc_action, errors) do
+    # Get the action to check if it's update/destroy (identities only apply to these)
+    action = Ash.Resource.Info.action(resource, rpc_action.action)
+
+    if action && action.type in [:update, :destroy] do
+      identities = Map.get(rpc_action, :identities, [:_primary_key])
+      validate_identities_exist(resource, rpc_action, identities, errors)
+    else
+      errors
+    end
+  end
+
+  defp validate_identities_exist(resource, rpc_action, identities, errors) do
+    Enum.reduce(identities, errors, fn identity, acc ->
+      case identity do
+        :_primary_key ->
+          # Verify the resource actually has a primary key
+          case Ash.Resource.Info.primary_key(resource) do
+            [] ->
+              [
+                {:no_primary_key, rpc_action.name, rpc_action.action, resource}
+                | acc
+              ]
+
+            _ ->
+              acc
+          end
+
+        identity_name when is_atom(identity_name) ->
+          # Check if the identity exists on the resource
+          if Ash.Resource.Info.identity(resource, identity_name) do
+            acc
+          else
+            available_identities = get_available_identities(resource)
+
+            [
+              {:identity_not_found, rpc_action.name, rpc_action.action, identity_name,
+               available_identities}
+              | acc
+            ]
+          end
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp get_available_identities(resource) do
+    resource
+    |> Ash.Resource.Info.identities()
+    |> Enum.map(& &1.name)
+  end
+
+  defp format_identity_validation_errors(errors) do
+    message_parts = Enum.map_join(errors, "\n\n", &format_error_part/1)
+
+    {:error,
+     Spark.Error.DslError.exception(
+       message: """
+       Invalid identity configuration found in RPC actions.
+
+       #{message_parts}
+
+       Each identity listed in the `identities` option must either be `:_primary_key` (for the resource's primary key)
+       or the name of an identity defined on the resource.
+       """
+     )}
+  end
+
+  defp format_error_part(
+         {:identity_not_found, rpc_name, action_name, identity_name, available_identities}
+       ) do
+    available_str =
+      case available_identities do
+        [] ->
+          "No identities are defined on this resource."
+
+        identities ->
+          "Available identities: #{Enum.map_join(identities, ", ", &inspect/1)}"
+      end
+
+    """
+    Identity not found on resource:
+      - RPC action: #{rpc_name} (action: #{action_name})
+      - Identity: #{inspect(identity_name)}
+      - #{available_str}
+      - Note: Use `:_primary_key` to reference the resource's primary key.
+    """
+  end
+
+  defp format_error_part({:no_primary_key, rpc_name, action_name, resource}) do
+    """
+    Resource has no primary key but :_primary_key identity is configured:
+      - RPC action: #{rpc_name} (action: #{action_name})
+      - Resource: #{inspect(resource)}
+      - Either define a primary key on the resource, use a named identity, or use `identities: []` for actor-scoped actions.
+    """
+  end
+end

--- a/lib/ash_kotlin_multiplatform/verifier_checker.ex
+++ b/lib/ash_kotlin_multiplatform/verifier_checker.ex
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.VerifierChecker do
+  @moduledoc """
+  Checks if any verifiers have failed for resources and domains.
+
+  This is needed because Spark verifiers now emit warnings instead of errors,
+  so we need to re-run them during codegen to detect issues.
+  """
+
+  @doc """
+  Checks all verifiers for a list of modules (resources/domains).
+  Returns :ok or {:error, formatted_message}
+  """
+  def check_all_verifiers(modules) do
+    errors =
+      modules
+      |> Enum.flat_map(&check_module_verifiers/1)
+
+    case errors do
+      [] -> :ok
+      errors -> {:error, format_verifier_errors(errors)}
+    end
+  end
+
+  defp check_module_verifiers(module) do
+    extensions = Spark.extensions(module)
+    dsl_config = module.spark_dsl_config()
+
+    ash_kotlin_extensions = [AshKotlinMultiplatform.Resource, AshKotlinMultiplatform.Rpc]
+
+    extensions
+    |> Enum.filter(&(&1 in ash_kotlin_extensions))
+    |> Enum.flat_map(fn extension ->
+      Code.ensure_loaded!(extension)
+
+      if function_exported?(extension, :verifiers, 0) do
+        extension.verifiers()
+      else
+        []
+      end
+    end)
+    |> Enum.flat_map(fn verifier ->
+      check_single_verifier(module, verifier, dsl_config)
+    end)
+  end
+
+  defp check_single_verifier(module, verifier, dsl_config) do
+    case verifier.verify(dsl_config) do
+      :ok ->
+        []
+
+      {:warn, warnings} ->
+        warnings_list = List.wrap(warnings)
+
+        Enum.map(warnings_list, fn warning ->
+          {module, verifier, warning}
+        end)
+
+      {:error, error} ->
+        [{module, verifier, error}]
+    end
+  rescue
+    e -> [{module, verifier, e}]
+  end
+
+  defp format_verifier_errors(errors) do
+    errors
+    |> Enum.map_join("\n\n", fn {module, verifier, error} ->
+      """
+      Module: #{inspect(module)}
+      Verifier: #{inspect(verifier)}
+      Error: #{format_error(error)}
+      """
+      |> String.trim()
+    end)
+  end
+
+  defp format_error(%Spark.Error.DslError{message: message}), do: message
+  defp format_error(error) when is_binary(error), do: error
+  defp format_error(error), do: Exception.message(error)
+end

--- a/test/ash_kotlin_multiplatform/helpers_test.exs
+++ b/test/ash_kotlin_multiplatform/helpers_test.exs
@@ -21,8 +21,8 @@ defmodule AshKotlinMultiplatform.HelpersTest do
     end
 
     test "handles leading underscore" do
-      # Leading underscores are treated as empty segments and capitalized
-      assert Helpers.snake_to_camel_case("_private_field") == "PrivateField"
+      # Leading underscores are treated as empty segments, result is still camelCase
+      assert Helpers.snake_to_camel_case("_private_field") == "privateField"
     end
   end
 
@@ -50,8 +50,8 @@ defmodule AshKotlinMultiplatform.HelpersTest do
     end
 
     test "handles consecutive capitals" do
-      # Consecutive capitals are treated as single words
-      assert Helpers.camel_to_snake_case("XMLParser") == "xmlparser"
+      # Consecutive capitals are properly separated with underscores
+      assert Helpers.camel_to_snake_case("XMLParser") == "xml_parser"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Refactors ash_kotlin_multiplatform to use a modular code generation architecture that aligns with ash_typescript
- Leverages ash_introspection as the shared foundation for common functionality
- Adds compile-time verifiers for validation
- Introduces modular function generators, type generators, and helper modules

## New Modules

**Verifiers:**
- `resource/verifiers/verify_field_names.ex` - Validates field names for Kotlin compatibility
- `resource/verifiers/verify_unique_type_names.ex` - Ensures unique type names across resources
- `rpc/verifiers/verify_identities.ex` - Verifies RPC action identities exist
- `rpc/verifiers/verify_action_types.ex` - Validates action return/argument types
- `verifier_checker.ex` - Re-runs verifiers during codegen

**Function Generators:**
- `function_generators/function_core.ex` - Transport-agnostic function shape building
- `function_generators/http_renderer.ex` - Ktor-based HTTP function generation

**Helpers:**
- `helpers/action_introspection.ex` - Delegates to ash_introspection
- `helpers/config_builder.ex` - Generates Kotlin config types
- `helpers/payload_builder.ex` - Generates request payload construction

**Type Generators:**
- `type_generators/metadata_types.ex` - Action metadata data classes
- `type_generators/pagination_types.ex` - Offset/keyset/mixed pagination result types

**Static Code:**
- `kotlin_static.ex` - Static Kotlin code (imports, type aliases, error types)
- `rpc_config_collector.ex` - Collects RPC configuration from domains

## Test plan

- [x] All 39 tests pass
- [x] Compilation succeeds with no warnings
- [x] Mix task `ash_kotlin_multiplatform.codegen` is available