### PR TITLE
docs: prepare for hex release with alpha warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-01-XX
+
+> **Alpha Release** - This is an early alpha release. The API may change between versions.
+
+### Added
+
+- Initial release of AshKotlinMultiplatform
+- `AshKotlinMultiplatform.Resource` extension for resource-level Kotlin configuration
+  - `type_name` option for custom Kotlin class names
+  - `field_names` option for mapping field names to valid Kotlin identifiers
+  - `argument_names` option for mapping action argument names
+- `AshKotlinMultiplatform.Rpc` extension for domain-level RPC configuration
+  - `rpc_action` for exposing Ash actions as RPC endpoints
+  - `typed_query` for defining pre-configured queries with filters
+  - Metadata exposure control
+- Code generation via `mix ash_kotlin_multiplatform.codegen`
+  - Kotlin data classes with `@Serializable` annotations
+  - Sealed classes for type-safe action results
+  - Input configuration types for each action
+  - Pagination support (offset and keyset)
+  - Optional filter types for type-safe filtering
+  - Optional validation functions and annotations
+- Phoenix Channel client generation for WebSocket support
+- HTTP client generation using Ktor
+- kotlinx.serialization integration
+- Support for kotlinx-datetime and java.time
+- Configurable nullable strategies (explicit vs platform types)
+- Field name formatters (camel case conversion)
+- Lifecycle hooks for request/response processing
+- Verifiers for compile-time validation
+  - Field name validation
+  - Unique type name validation
+  - Action type compatibility validation
+  - Resource identity validation
+
+### Dependencies
+
+- Requires Ash 3.7+
+- Requires Spark 2.0+
+- Requires Elixir 1.15+
+
+[Unreleased]: https://github.com/ash-project/ash_kotlin_multiplatform/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/ash-project/ash_kotlin_multiplatform/releases/tag/v0.1.0

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 ash_kotlin_multiplatform contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
 # AshKotlinMultiplatform
 
+[![Hex.pm](https://img.shields.io/hexpm/v/ash_kotlin_multiplatform.svg)](https://hex.pm/packages/ash_kotlin_multiplatform)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-blue.svg)](https://hexdocs.pm/ash_kotlin_multiplatform)
+
 Generate type-safe Kotlin Multiplatform clients from your Ash resources.
+
+> **Alpha Software Notice**
+>
+> This library is in **alpha** and under active development. The API may change
+> between versions without notice. While functional and tested, it is not yet
+> recommended for production use. Please report issues and feedback on
+> [GitHub](https://github.com/ash-project/ash_kotlin_multiplatform/issues).
 
 ## Features
 
@@ -10,6 +20,17 @@ Generate type-safe Kotlin Multiplatform clients from your Ash resources.
 - **kotlinx.serialization** integration for JSON handling
 - **Phoenix Channel support** for real-time applications
 - **Kotlin Multiplatform** support (JVM, iOS, JS, Native)
+- **Type-safe filtering** with generated filter types
+- **Pagination support** for offset and keyset pagination
+- **Validation** with optional javax.validation annotations
+
+## Requirements
+
+- Elixir 1.15+
+- Ash 3.7+
+- Kotlin 1.9+ (for generated code)
+- Ktor 2.0+ (for HTTP client)
+- kotlinx.serialization 1.6+ (for JSON)
 
 ## Installation
 
@@ -27,6 +48,8 @@ end
 
 ### 1. Add the Resource Extension
 
+Configure your Ash resources with the `AshKotlinMultiplatform.Resource` extension:
+
 ```elixir
 defmodule MyApp.Todo do
   use Ash.Resource,
@@ -34,22 +57,36 @@ defmodule MyApp.Todo do
     extensions: [AshKotlinMultiplatform.Resource]
 
   kotlin_multiplatform do
+    # Optional: customize the Kotlin class name
     type_name "Todo"
+
+    # Optional: map Elixir field names to valid Kotlin identifiers
+    field_names %{
+      is_done: :isDone,
+      created_at: :createdAt
+    }
   end
 
   attributes do
     uuid_primary_key :id
     attribute :title, :string, allow_nil?: false
-    attribute :completed, :boolean, default: false
+    attribute :is_done, :boolean, default: false
+    attribute :created_at, :utc_datetime_usec
   end
 
   actions do
     defaults [:read, :create, :update, :destroy]
+
+    read :list do
+      pagination offset?: true, default_limit: 25
+    end
   end
 end
 ```
 
 ### 2. Add the Domain Extension
+
+Configure your Ash domain with the `AshKotlinMultiplatform.Rpc` extension to expose actions via RPC:
 
 ```elixir
 defmodule MyApp.Domain do
@@ -57,11 +94,17 @@ defmodule MyApp.Domain do
 
   kotlin_rpc do
     resource MyApp.Todo do
-      rpc_action :list_todos, :read
+      # Map RPC endpoint names to Ash actions
+      rpc_action :list_todos, :list
       rpc_action :create_todo, :create
       rpc_action :get_todo, :read
       rpc_action :update_todo, :update
       rpc_action :delete_todo, :destroy
+
+      # Optional: define typed queries for common operations
+      typed_query :active_todos, :list do
+        filter is_done: false
+      end
     end
   end
 
@@ -73,11 +116,17 @@ end
 
 ### 3. Generate Kotlin Code
 
+Run the code generation mix task:
+
 ```bash
 mix ash_kotlin_multiplatform.codegen
 ```
 
+This generates a Kotlin file (default: `lib/generated/AshRpc.kt`) containing all your types and RPC functions.
+
 ## Generated Code Example
+
+The generator produces idiomatic Kotlin code:
 
 ```kotlin
 package com.myapp.ash
@@ -86,13 +135,27 @@ import kotlinx.serialization.*
 import kotlinx.datetime.*
 import io.ktor.client.*
 
-// Data class
+// Data class with serialization support
 @Serializable
 data class Todo(
     val id: String,
     val title: String,
-    val completed: Boolean? = false
+    val isDone: Boolean? = false,
+    val createdAt: Instant? = null
 )
+
+// Configuration for actions
+@Serializable
+data class CreateTodoConfig(
+    val title: String,
+    val isDone: Boolean? = null
+)
+
+// Sealed class for type-safe results
+sealed class CreateTodoResult {
+    data class Ok(val data: Todo) : CreateTodoResult()
+    data class Error(val errors: List<RpcError>) : CreateTodoResult()
+}
 
 // Functional API
 suspend fun createTodo(
@@ -100,28 +163,168 @@ suspend fun createTodo(
     config: CreateTodoConfig
 ): CreateTodoResult { ... }
 
-// Object-oriented API
+// Object-oriented API wrapper
 object TodoRpc {
-    suspend fun create(client: HttpClient, config: CreateTodoConfig) = createTodo(client, config)
-    suspend fun list(client: HttpClient, config: ListTodosConfig) = listTodos(client, config)
+    suspend fun create(client: HttpClient, config: CreateTodoConfig) =
+        createTodo(client, config)
+    suspend fun list(client: HttpClient, config: ListTodosConfig) =
+        listTodos(client, config)
 }
 ```
 
 ## Configuration
 
+Configure the generator in your `config/config.exs`:
+
 ```elixir
 config :ash_kotlin_multiplatform,
+  # Output settings
   output_file: "lib/generated/AshRpc.kt",
   package_name: "com.myapp.ash",
+
+  # Code generation options
   generate_phoenix_channel_client: true,
-  datetime_library: :kotlinx_datetime,
-  nullable_strategy: :explicit
+  generate_validation_functions: true,
+  generate_filter_types: false,
+  generate_validation_annotations: false,
+
+  # Type handling
+  datetime_library: :kotlinx_datetime,  # or :java_time
+  nullable_strategy: :explicit,         # or :platform
+
+  # RPC endpoints
+  run_endpoint: "/rpc/run",
+  validate_endpoint: "/rpc/validate",
+
+  # Warnings
+  warn_on_missing_rpc_config: true,
+  warn_on_non_rpc_references: true
 ```
 
-## Documentation
+### Configuration Options
 
-- [Getting Started Guide](documentation/tutorials/getting-started.md)
-- [Configuration Reference](documentation/reference/configuration.md)
+| Option | Default | Description |
+|--------|---------|-------------|
+| `output_file` | `"lib/generated/AshRpc.kt"` | Path for generated Kotlin file |
+| `package_name` | Auto-generated | Kotlin package name |
+| `generate_phoenix_channel_client` | `true` | Generate WebSocket client code |
+| `generate_validation_functions` | `true` | Generate input validation functions |
+| `generate_filter_types` | `false` | Generate type-safe filter types |
+| `generate_validation_annotations` | `false` | Add javax.validation annotations |
+| `datetime_library` | `:kotlinx_datetime` | Date/time library (`:kotlinx_datetime` or `:java_time`) |
+| `nullable_strategy` | `:explicit` | Nullable handling (`:explicit` for `T?`, `:platform` for `T!`) |
+| `run_endpoint` | `"/rpc/run"` | RPC execution endpoint |
+| `validate_endpoint` | `"/rpc/validate"` | Validation endpoint |
+| `type_mapping_overrides` | `[]` | Custom Ash to Kotlin type mappings |
+| `input_field_formatter` | `:camel_case` | Input field name format |
+| `output_field_formatter` | `:camel_case` | Output field name format |
+
+## DSL Reference
+
+### Resource Extension (`AshKotlinMultiplatform.Resource`)
+
+```elixir
+kotlin_multiplatform do
+  # Custom Kotlin class name (default: resource module name)
+  type_name "MyCustomName"
+
+  # Map field names to valid Kotlin identifiers
+  field_names %{
+    elixir_name: :kotlinName
+  }
+
+  # Map argument names per action
+  argument_names %{
+    create: %{from_date: :fromDate}
+  }
+end
+```
+
+### Domain Extension (`AshKotlinMultiplatform.Rpc`)
+
+```elixir
+kotlin_rpc do
+  resource MyApp.Resource do
+    # Map RPC actions to Ash actions
+    rpc_action :rpc_name, :ash_action_name
+
+    # Expose metadata fields
+    rpc_action :list_items, :read do
+      expose_metadata [:total_count]
+    end
+
+    # Define typed queries with preset filters
+    typed_query :active_items, :read do
+      filter status: :active
+    end
+  end
+end
+```
+
+## Phoenix Channel Support
+
+When `generate_phoenix_channel_client: true`, the generator creates a full Phoenix Channel client:
+
+```kotlin
+// Connect to Phoenix Channel
+val channel = AshRpcChannel(
+    httpClient = client,
+    baseUrl = "ws://localhost:4000/socket/websocket"
+)
+
+// Join the RPC topic
+channel.join("rpc:lobby")
+
+// Make RPC calls over WebSocket
+val result = channel.call<CreateTodoResult>("create_todo", config)
+```
+
+## Advanced Features
+
+### Type-Safe Filters
+
+Enable with `generate_filter_types: true`:
+
+```kotlin
+val filter = TodoFilter(
+    title = StringFilter(contains = "important"),
+    isDone = BooleanFilter(eq = false)
+)
+
+val result = listTodos(client, ListTodosConfig(filter = filter))
+```
+
+### Custom Type Mappings
+
+Map custom Ash types to Kotlin:
+
+```elixir
+config :ash_kotlin_multiplatform,
+  type_mapping_overrides: [
+    {MyApp.Types.Money, "BigDecimal"},
+    {MyApp.Types.Email, "String"}
+  ]
+```
+
+### Lifecycle Hooks
+
+Add hooks for request processing:
+
+```elixir
+config :ash_kotlin_multiplatform,
+  rpc_action_before_request_hook: "authInterceptor",
+  rpc_action_after_request_hook: "responseLogger"
+```
+
+## Related Packages
+
+- [ash](https://hex.pm/packages/ash) - The Ash Framework
+- [ash_phoenix](https://hex.pm/packages/ash_phoenix) - Phoenix integration for Ash
+- [ash_json_api](https://hex.pm/packages/ash_json_api) - JSON:API support for Ash
+
+## Contributing
+
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 

--- a/lib/ash_kotlin_multiplatform.ex
+++ b/lib/ash_kotlin_multiplatform.ex
@@ -6,6 +6,12 @@ defmodule AshKotlinMultiplatform do
   @moduledoc """
   Generate type-safe Kotlin Multiplatform clients from your Ash resources.
 
+  > #### Alpha Software {: .warning}
+  >
+  > This library is in **alpha** and under active development. The API may change
+  > between versions without notice. Please report issues on
+  > [GitHub](https://github.com/ash-project/ash_kotlin_multiplatform/issues).
+
   AshKotlinMultiplatform provides:
   - Automatic generation of Kotlin data classes from Ash resources
   - Type-safe RPC functions using Ktor client

--- a/mix.exs
+++ b/mix.exs
@@ -10,6 +10,8 @@ defmodule AshKotlinMultiplatform.MixProject do
   @description """
   Generate type-safe Kotlin Multiplatform clients directly from your Ash resources and actions,
   ensuring end-to-end type safety between your backend and frontend.
+
+  **Alpha Software** - This library is under active development. The API may change between versions.
   """
 
   def project do
@@ -21,9 +23,11 @@ defmodule AshKotlinMultiplatform.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       package: package(),
       deps: deps(),
+      docs: docs(),
       description: @description,
-      source_url: "https://github.com/ash-project/ash_interop",
-      homepage_url: "https://github.com/ash-project/ash_interop",
+      name: "AshKotlinMultiplatform",
+      source_url: "https://github.com/ash-project/ash_kotlin_multiplatform",
+      homepage_url: "https://github.com/ash-project/ash_kotlin_multiplatform",
       consolidate_protocols: Mix.env() != :test
     ]
   end
@@ -43,9 +47,9 @@ defmodule AshKotlinMultiplatform.MixProject do
         "Peter Shoukry"
       ],
       licenses: ["MIT"],
-      files: ~w(lib .formatter.exs mix.exs README* CHANGELOG* LICENSES),
+      files: ~w(lib .formatter.exs mix.exs README* CHANGELOG* LICENSE*),
       links: %{
-        "GitHub" => "https://github.com/ash-project/ash_interop",
+        "GitHub" => "https://github.com/ash-project/ash_kotlin_multiplatform",
         "Discord" => "https://discord.gg/HTHRaaVPUc",
         "Website" => "https://ash-hq.org",
         "Forum" => "https://elixirforum.com/c/elixir-framework-forums/ash-framework-forum"
@@ -53,9 +57,50 @@ defmodule AshKotlinMultiplatform.MixProject do
     ]
   end
 
+  defp docs do
+    [
+      main: "readme",
+      source_ref: "v#{@version}",
+      extras: [
+        {"README.md", title: "Home"},
+        {"CHANGELOG.md", title: "Changelog"},
+        {"LICENSE", title: "License"}
+      ],
+      groups_for_modules: [
+        "DSL Extensions": [
+          AshKotlinMultiplatform.Resource,
+          AshKotlinMultiplatform.Rpc
+        ],
+        "Code Generation": [
+          AshKotlinMultiplatform.Rpc.Codegen,
+          AshKotlinMultiplatform.Codegen.TypeMapper,
+          AshKotlinMultiplatform.Codegen.TypeDiscovery,
+          AshKotlinMultiplatform.Codegen.ResourceSchemas
+        ],
+        "RPC Pipeline": [
+          AshKotlinMultiplatform.Rpc.Pipeline,
+          AshKotlinMultiplatform.Rpc.Hooks
+        ]
+      ],
+      before_closing_head_tag: fn _type ->
+        """
+        <style>
+          .warning {
+            background-color: #fff3cd;
+            border: 1px solid #ffc107;
+            border-radius: 4px;
+            padding: 1rem;
+            margin: 1rem 0;
+          }
+        </style>
+        """
+      end
+    ]
+  end
+
   defp deps do
     [
-      {:ash_introspection, path: "../ash_introspection"},
+      {:ash_introspection, "~> 0.2.0"},
       {:ash, "~> 3.7"},
       {:ash_phoenix, "~> 2.0"},
       {:spark, "~> 2.0"},


### PR DESCRIPTION
## Summary

- Add comprehensive README with alpha software notice, requirements, configuration options table, DSL reference, and usage examples
- Create CHANGELOG.md following Keep a Changelog format
- Create LICENSE file (MIT)
- Update mix.exs with docs configuration, correct GitHub URLs, and hex package file list
- Add alpha warning to main module documentation
- Switch ash_introspection from path to hex dependency (~> 0.2.0)

## Test plan

- [x] Verify `mix hex.build` succeeds
- [x] Review generated documentation with `mix docs`
- [x] Publish to hex.pm with `mix hex.publish`