### PR TITLE
chore: update GitHub links to udin-io org

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Generate type-safe Kotlin Multiplatform clients from your Ash resources.
 > This library is in **alpha** and under active development. The API may change
 > between versions without notice. While functional and tested, it is not yet
 > recommended for production use. Please report issues and feedback on
-> [GitHub](https://github.com/ash-project/ash_kotlin_multiplatform/issues).
+> [GitHub](https://github.com/udin-io/ash_kotlin_multiplatform/issues).
 
 ## Features
 

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,8 @@ defmodule AshKotlinMultiplatform.MixProject do
       docs: docs(),
       description: @description,
       name: "AshKotlinMultiplatform",
-      source_url: "https://github.com/ash-project/ash_kotlin_multiplatform",
-      homepage_url: "https://github.com/ash-project/ash_kotlin_multiplatform",
+      source_url: "https://github.com/udin-io/ash_kotlin_multiplatform",
+      homepage_url: "https://github.com/udin-io/ash_kotlin_multiplatform",
       consolidate_protocols: Mix.env() != :test
     ]
   end
@@ -49,10 +49,9 @@ defmodule AshKotlinMultiplatform.MixProject do
       licenses: ["MIT"],
       files: ~w(lib .formatter.exs mix.exs README* CHANGELOG* LICENSE*),
       links: %{
-        "GitHub" => "https://github.com/ash-project/ash_kotlin_multiplatform",
+        "GitHub" => "https://github.com/udin-io/ash_kotlin_multiplatform",
         "Discord" => "https://discord.gg/HTHRaaVPUc",
-        "Website" => "https://ash-hq.org",
-        "Forum" => "https://elixirforum.com/c/elixir-framework-forums/ash-framework-forum"
+        "Website" => "https://ash-hq.org"
       }
     ]
   end


### PR DESCRIPTION
## Summary
- Update all GitHub URLs from ash-project to udin-io organization
- Remove Forum link from package metadata

## Test plan
- [x] Verify links in hex.pm after publishing