### PR TITLE
fix: serialize kotlinx Instant fields across kotlinx-datetime version…

### DIFF
--- a/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
@@ -184,14 +184,14 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypes do
 
     @Serializable
     data class InstantFilter(
-        val eq: kotlinx.datetime.Instant? = null,
-        val notEq: kotlinx.datetime.Instant? = null,
-        val greaterThan: kotlinx.datetime.Instant? = null,
-        val greaterThanOrEqual: kotlinx.datetime.Instant? = null,
-        val lessThan: kotlinx.datetime.Instant? = null,
-        val lessThanOrEqual: kotlinx.datetime.Instant? = null,
+        val eq: @Contextual kotlinx.datetime.Instant? = null,
+        val notEq: @Contextual kotlinx.datetime.Instant? = null,
+        val greaterThan: @Contextual kotlinx.datetime.Instant? = null,
+        val greaterThanOrEqual: @Contextual kotlinx.datetime.Instant? = null,
+        val lessThan: @Contextual kotlinx.datetime.Instant? = null,
+        val lessThanOrEqual: @Contextual kotlinx.datetime.Instant? = null,
         @SerialName("in")
-        val inValues: List<kotlinx.datetime.Instant>? = null
+        val inValues: List<@Contextual kotlinx.datetime.Instant>? = null
     )
 
     @Serializable

--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -187,12 +187,7 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
           {nullable_type, " = #{default_value}"}
       end
 
-    # kotlinx-datetime's Instant has no default serializer; @Contextual defers to the
-    # SerializersModule registered in KotlinStatic.generate_http_client_factory/0.
-    contextual =
-      if String.contains?(kotlin_type, "kotlinx.datetime.Instant"), do: "@Contextual ", else: ""
-
-    "#{serial_name}#{contextual}val #{field_name}: #{kotlin_type}#{default}"
+    "#{serial_name}val #{field_name}: #{TypeMapper.annotate_contextual_types(kotlin_type)}#{default}"
   end
 
   defp make_nullable(kotlin_type) do

--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -187,7 +187,12 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
           {nullable_type, " = #{default_value}"}
       end
 
-    "#{serial_name}val #{field_name}: #{kotlin_type}#{default}"
+    # kotlinx-datetime's Instant has no default serializer; @Contextual defers to the
+    # SerializersModule registered in KotlinStatic.generate_http_client_factory/0.
+    contextual =
+      if String.contains?(kotlin_type, "kotlinx.datetime.Instant"), do: "@Contextual ", else: ""
+
+    "#{serial_name}#{contextual}val #{field_name}: #{kotlin_type}#{default}"
   end
 
   defp make_nullable(kotlin_type) do

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -17,6 +17,9 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
 
   alias AshIntrospection.TypeSystem.Introspection
 
+  # Kotlin types with no serializer the compiler can resolve on its own.
+  @contextual_types ["kotlinx.datetime.Instant"]
+
   @doc """
   Returns the Kotlin type for an Ash attribute.
 
@@ -53,6 +56,31 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   """
   def get_kotlin_type_for_type(type, constraints \\ []) do
     do_get_kotlin_type(type, constraints)
+  end
+
+  @doc """
+  Annotates the types that have no compile-time serializer with `@Contextual`.
+
+  `kotlinx.datetime.Instant` is the only such type. kotlinx-datetime 0.6 shipped a
+  default serializer for it; 0.7 deprecated the class in favour of
+  `kotlin.time.Instant` and dropped both the default and the concrete
+  `InstantIso8601Serializer` object. A generated file cannot know which version the
+  consumer pinned, so it defers the lookup to the `SerializersModule` that
+  `AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic.generate_http_client_factory/0`
+  registers.
+
+  Annotates in type position rather than on the property, so element types resolve
+  too: `List<@Contextual Instant>` consults the module for `Instant`, while
+  `@Contextual val x: List<Instant>` would look for a serializer registered for
+  `List<Instant>` and fail at runtime.
+
+  `java.time.Instant` is left alone — `:java_time` consumers supply their own
+  serializers. Idempotent, so it is safe to apply to an already-annotated type.
+  """
+  def annotate_contextual_types(kotlin_type) when is_binary(kotlin_type) do
+    Enum.reduce(@contextual_types, kotlin_type, fn type, acc ->
+      String.replace(acc, ~r/(?<!@Contextual )\b#{Regex.escape(type)}\b/, "@Contextual #{type}")
+    end)
   end
 
   defp do_get_kotlin_type(type, constraints) do

--- a/lib/ash_kotlin_multiplatform/codegen/typed_queries.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/typed_queries.ex
@@ -196,7 +196,7 @@ defmodule AshKotlinMultiplatform.Codegen.TypedQueries do
     attr = get_attribute_or_calculation(resource, field)
 
     if attr do
-      kotlin_type = TypeMapper.get_kotlin_type(attr)
+      kotlin_type = TypeMapper.annotate_contextual_types(TypeMapper.get_kotlin_type(attr))
       formatted_name = format_field_for_client(field, resource)
 
       if formatted_name != to_string(field) do

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
@@ -146,7 +146,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
       if MetadataTypes.metadata_enabled?(
            MetadataTypes.get_exposed_metadata_fields(rpc_action, action)
          ) do
-        fields ++ [{:metadata_fields, "List<Any>?", true, "null"}]
+        fields ++ [{:metadata_fields, "List<String>?", true, "null"}]
       else
         fields
       end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
@@ -12,6 +12,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
 
   alias AshKotlinMultiplatform.Codegen.TypeMapper
   alias AshKotlinMultiplatform.Rpc.Codegen.Helpers.ActionIntrospection
+  alias AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.MetadataTypes
   alias AshIntrospection.Helpers
 
   @doc """
@@ -133,6 +134,19 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
     fields =
       if context.supports_pagination do
         fields ++ [{:page, "Map<String, @Contextual Any?>?", true, "null"}]
+      else
+        fields
+      end
+
+    # Add metadata fields selector when the action exposes metadata (mirrors the
+    # has_metadata check in FunctionCore.build_execution_function_shape/5 — the two
+    # must stay in sync, or the emitted function body references a config property
+    # that was never declared on the class).
+    fields =
+      if MetadataTypes.metadata_enabled?(
+           MetadataTypes.get_exposed_metadata_fields(rpc_action, action)
+         ) do
+        fields ++ [{:metadata_fields, "List<Any>?", true, "null"}]
       else
         fields
       end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -15,8 +15,22 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   def generate_imports(opts \\ []) do
     datetime_imports =
       case AshKotlinMultiplatform.datetime_library() do
-        :kotlinx_datetime -> "import kotlinx.datetime.*"
-        :java_time -> "import java.time.*"
+        :kotlinx_datetime ->
+          """
+          import kotlinx.datetime.*
+          import kotlinx.serialization.KSerializer
+          import kotlinx.serialization.descriptors.PrimitiveKind
+          import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+          import kotlinx.serialization.descriptors.SerialDescriptor
+          import kotlinx.serialization.encoding.Decoder
+          import kotlinx.serialization.encoding.Encoder
+          import kotlinx.serialization.modules.SerializersModule
+          import kotlinx.serialization.modules.contextual
+          """
+          |> String.trim_trailing()
+
+        :java_time ->
+          "import java.time.*"
       end
 
     websocket_imports =
@@ -58,14 +72,48 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   Generates a helper function to create a configured HttpClient.
   """
   def generate_http_client_factory do
+    # kotlinx-datetime 0.7 removed the concrete InstantIso8601Serializer object (Instant is
+    # deprecated in favor of kotlin.time.Instant there) in favor of an abstract
+    # FormattedInstantSerializer base that doesn't exist before 0.7. Neither name is safe to
+    # reference unconditionally — this codegen has no way to know which kotlinx-datetime
+    # version a given consumer has pinned — so this hand-writes a KSerializer against only
+    # Instant.toString()/Instant.parse(), which are stable ISO-8601 API across that version
+    # split. Fields typed as Instant are emitted as @Contextual (see
+    # ResourceSchemas.generate_field/1) and resolved through the SerializersModule below at
+    # runtime.
+    {instant_serializer_decl, serializers_module} =
+      case AshKotlinMultiplatform.datetime_library() do
+        :kotlinx_datetime ->
+          decl = """
+          private object InstantIso8601Serializer : KSerializer<kotlinx.datetime.Instant> {
+              override val descriptor: SerialDescriptor =
+                  PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
+
+              override fun serialize(encoder: Encoder, value: kotlinx.datetime.Instant) {
+                  encoder.encodeString(value.toString())
+              }
+
+              override fun deserialize(decoder: Decoder): kotlinx.datetime.Instant {
+                  return kotlinx.datetime.Instant.parse(decoder.decodeString())
+              }
+          }
+
+          """
+
+          {decl, "\n                    serializersModule = SerializersModule { contextual(InstantIso8601Serializer) }"}
+
+        :java_time ->
+          {"", ""}
+      end
+
     """
-    // HTTP Client factory
+    #{instant_serializer_decl}// HTTP Client factory
     fun createHttpClient(): HttpClient {
         return HttpClient {
             install(ContentNegotiation) {
                 json(Json {
                     ignoreUnknownKeys = true
-                    isLenient = true
+                    isLenient = true#{serializers_module}
                 })
             }
         }

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -100,7 +100,8 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
 
           """
 
-          {decl, "\n                    serializersModule = SerializersModule { contextual(InstantIso8601Serializer) }"}
+          {decl,
+           "\n                    serializersModule = SerializersModule { contextual(InstantIso8601Serializer) }"}
 
         :java_time ->
           {"", ""}

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/input_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/input_types.ex
@@ -118,7 +118,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.InputTypes do
           {kotlin_type, ""}
       end
 
-    "#{serial_name}val #{field_name}: #{type_with_nullability}#{default}"
+    "#{serial_name}val #{field_name}: #{TypeMapper.annotate_contextual_types(type_with_nullability)}#{default}"
   end
 
   defp generate_attribute_field(attribute, action) do
@@ -153,7 +153,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.InputTypes do
           {kotlin_type, ""}
       end
 
-    "#{serial_name}val #{field_name}: #{type_with_nullability}#{default}"
+    "#{serial_name}val #{field_name}: #{TypeMapper.annotate_contextual_types(type_with_nullability)}#{default}"
   end
 
   # Determines if an attribute is optional for the given action

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
@@ -94,12 +94,16 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.MetadataTypes do
 
       metadata_field_defs =
         Enum.map(metadata_fields_to_include, fn metadata_field ->
-          kotlin_type = TypeMapper.get_kotlin_type_for_type(metadata_field.type, metadata_field.constraints || [])
+          kotlin_type =
+            metadata_field.type
+            |> TypeMapper.get_kotlin_type_for_type(metadata_field.constraints || [])
+            |> TypeMapper.annotate_contextual_types()
 
           optional = Map.get(metadata_field, :allow_nil?, true)
 
           # Check for mapped metadata field names
           metadata_field_names = Map.get(rpc_action, :metadata_field_names, [])
+
           mapped_name = Keyword.get(metadata_field_names, metadata_field.name, metadata_field.name)
           formatted_name = Helpers.snake_to_camel_case(mapped_name)
 

--- a/test/ash_kotlin_multiplatform/codegen/instant_serialization_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/instant_serialization_test.exs
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Codegen.InstantSerializationTest do
+  @moduledoc """
+  Every `kotlinx.datetime.Instant` the generator emits must be annotated
+  `@Contextual`, in every `@Serializable` class and in type position.
+
+  kotlinx-datetime 0.6 shipped a default serializer for `Instant`; 0.7 dropped it
+  when it deprecated the class in favour of `kotlin.time.Instant`. A bare field
+  therefore fails to compile on 0.7, and the generator cannot know which version a
+  consumer pinned. These tests exist because the first pass at that fix covered
+  only resource data classes and left the input, filter, metadata and typed-query
+  emitters broken.
+  """
+  use ExUnit.Case, async: false
+
+  alias AshKotlinMultiplatform.Codegen.FilterTypes
+  alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Codegen.TypedQueries
+  alias AshKotlinMultiplatform.Rpc.Codegen
+  alias AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.InputTypes
+  alias AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.MetadataTypes
+  alias AshKotlinMultiplatform.Test.Event
+
+  # The serializer's own declaration names Instant outside any field, so exempt it.
+  @serializer_lines [
+    "object InstantIso8601Serializer",
+    "PrimitiveSerialDescriptor(",
+    "fun serialize(",
+    "fun deserialize(",
+    "Instant.parse("
+  ]
+
+  defp bare_instants(kotlin) do
+    kotlin
+    |> String.split("\n")
+    |> Enum.reject(fn line -> Enum.any?(@serializer_lines, &String.contains?(line, &1)) end)
+    |> Enum.filter(fn line ->
+      String.contains?(line, "kotlinx.datetime.Instant") and
+        not String.contains?(line, "@Contextual kotlinx.datetime.Instant")
+    end)
+  end
+
+  defp assert_no_bare_instants(kotlin) do
+    assert bare_instants(kotlin) == [],
+           "Instant without @Contextual:\n" <> Enum.join(bare_instants(kotlin), "\n")
+  end
+
+  describe "resource data classes" do
+    test "annotates Instant attributes" do
+      kotlin = ResourceSchemas.generate_data_class(Event)
+
+      assert kotlin =~ "val occurredAt: @Contextual kotlinx.datetime.Instant? = null"
+      assert_no_bare_instants(kotlin)
+    end
+
+    test "annotates the element type of an Instant list, not the list itself" do
+      kotlin = ResourceSchemas.generate_data_class(Event)
+
+      assert kotlin =~ "val reminderAts: List<@Contextual kotlinx.datetime.Instant>? = null"
+    end
+
+    test "leaves types with a built-in serializer bare" do
+      kotlin = ResourceSchemas.generate_data_class(Event)
+
+      assert kotlin =~ "val startsOn: kotlinx.datetime.LocalDate? = null"
+    end
+  end
+
+  describe "action input types" do
+    test "annotates Instant attributes accepted by the action" do
+      kotlin = InputTypes.generate_input_type(Event, %{name: :create_event, action: :create})
+
+      assert kotlin =~ "val occurredAt: @Contextual kotlinx.datetime.Instant? = null"
+      assert kotlin =~ "val reminderAts: List<@Contextual kotlinx.datetime.Instant>? = null"
+      assert_no_bare_instants(kotlin)
+    end
+  end
+
+  describe "base filter types" do
+    test "annotates every InstantFilter field" do
+      assert_no_bare_instants(FilterTypes.generate_base_filter_types())
+    end
+  end
+
+  describe "action metadata types" do
+    test "annotates Instant metadata fields" do
+      action = %{
+        metadata: [
+          %{name: :confirmed_at, type: Ash.Type.UtcDatetime, constraints: [], allow_nil?: true}
+        ]
+      }
+
+      kotlin = MetadataTypes.generate_action_metadata_type(action, %{}, :confirm_user)
+
+      assert kotlin =~ "val confirmedAt: @Contextual kotlinx.datetime.Instant? = null"
+      assert_no_bare_instants(kotlin)
+    end
+  end
+
+  describe "typed query result types" do
+    test "annotates Instant fields" do
+      action = Ash.Resource.Info.action(Event, :read)
+      typed_query = %{name: :recent_events, fields: [:id, :occurred_at]}
+
+      kotlin =
+        TypedQueries.generate_typed_query_type_and_const(Event, action, typed_query, [Event])
+
+      assert kotlin =~ "@Contextual kotlinx.datetime.Instant"
+      assert_no_bare_instants(kotlin)
+    end
+  end
+
+  describe "the whole generated file" do
+    setup do
+      previous = Application.get_env(:ash_kotlin_multiplatform, :ash_domains)
+
+      Application.put_env(:ash_kotlin_multiplatform, :ash_domains, [
+        AshKotlinMultiplatform.Test.Domain
+      ])
+
+      on_exit(fn ->
+        case previous do
+          nil -> Application.delete_env(:ash_kotlin_multiplatform, :ash_domains)
+          value -> Application.put_env(:ash_kotlin_multiplatform, :ash_domains, value)
+        end
+      end)
+
+      :ok
+    end
+
+    test "carries no bare Instant anywhere" do
+      {:ok, kotlin} =
+        Codegen.generate_kotlin_code(:ash_kotlin_multiplatform, with_filters: true)
+
+      assert_no_bare_instants(kotlin)
+    end
+
+    test "registers the Instant serializer on the Json config" do
+      {:ok, kotlin} = Codegen.generate_kotlin_code(:ash_kotlin_multiplatform)
+
+      assert kotlin =~ "object InstantIso8601Serializer : KSerializer<kotlinx.datetime.Instant>"
+
+      assert kotlin =~
+               "serializersModule = SerializersModule { contextual(InstantIso8601Serializer) }"
+    end
+  end
+end

--- a/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
@@ -91,4 +91,47 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
       assert TypeMapper.get_kotlin_type_for_type(:unknown_type) == "Any"
     end
   end
+
+  describe "annotate_contextual_types/1" do
+    test "annotates a bare Instant in type position" do
+      assert TypeMapper.annotate_contextual_types("kotlinx.datetime.Instant") ==
+               "@Contextual kotlinx.datetime.Instant"
+    end
+
+    test "annotates a nullable Instant" do
+      assert TypeMapper.annotate_contextual_types("kotlinx.datetime.Instant?") ==
+               "@Contextual kotlinx.datetime.Instant?"
+    end
+
+    test "annotates the element type of a list, not the list" do
+      assert TypeMapper.annotate_contextual_types("List<kotlinx.datetime.Instant>?") ==
+               "List<@Contextual kotlinx.datetime.Instant>?"
+    end
+
+    test "annotates every occurrence in a nested type" do
+      assert TypeMapper.annotate_contextual_types(
+               "Map<kotlinx.datetime.Instant, List<kotlinx.datetime.Instant>>"
+             ) ==
+               "Map<@Contextual kotlinx.datetime.Instant, List<@Contextual kotlinx.datetime.Instant>>"
+    end
+
+    test "leaves types with a built-in serializer alone" do
+      assert TypeMapper.annotate_contextual_types("String?") == "String?"
+
+      assert TypeMapper.annotate_contextual_types("kotlinx.datetime.LocalDate") ==
+               "kotlinx.datetime.LocalDate"
+
+      assert TypeMapper.annotate_contextual_types("kotlinx.datetime.LocalDateTime") ==
+               "kotlinx.datetime.LocalDateTime"
+    end
+
+    test "leaves java.time.Instant alone" do
+      assert TypeMapper.annotate_contextual_types("java.time.Instant?") == "java.time.Instant?"
+    end
+
+    test "is idempotent" do
+      once = TypeMapper.annotate_contextual_types("kotlinx.datetime.Instant?")
+      assert TypeMapper.annotate_contextual_types(once) == once
+    end
+  end
 end

--- a/test/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder_test.exs
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilderTest do
+  @moduledoc """
+  The generated function body reads `config.metadataFields` for every action that
+  exposes metadata (see `PayloadBuilder.build_payload_code/3`). The Config class it
+  reads from is built here, so the two must agree — when they did not, the
+  generated Kotlin referenced a property that was never declared.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder
+  alias AshKotlinMultiplatform.Test.Event
+
+  defp config_for(action_name, rpc_name) do
+    action = Ash.Resource.Info.action(Event, action_name)
+    ConfigBuilder.generate_config_type(Event, action, %{}, rpc_name)
+  end
+
+  describe "generate_config_type/4" do
+    test "declares metadataFields for an action that exposes metadata" do
+      assert config_for(:register, :register_event) =~ "val metadataFields: List<String>? = null"
+    end
+
+    test "omits metadataFields for an action with no metadata" do
+      refute config_for(:create, :create_event) =~ "metadataFields"
+    end
+  end
+end

--- a/test/support/resources/event.ex
+++ b/test/support/resources/event.ex
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Test.Event do
+  @moduledoc """
+  Public date/time attributes in every shape the Kotlin generator has to serialize.
+
+  The other test resources leave their attributes private, so they exercise no
+  field generation at all — `Ash.Resource.Info.public_attributes/1` returns only
+  the primary key.
+  """
+  use Ash.Resource,
+    domain: AshKotlinMultiplatform.Test.Domain,
+    extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("Event")
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :name, :string do
+      public? true
+      allow_nil? false
+    end
+
+    attribute :starts_on, :date, public?: true
+    attribute :occurred_at, :utc_datetime, public?: true
+    attribute :recorded_at, :utc_datetime_usec, public?: true
+    attribute :reminder_ats, {:array, :utc_datetime}, public?: true
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      primary? true
+      accept [:name, :starts_on, :occurred_at, :reminder_ats]
+    end
+
+    # Exercises the metadata path: the Config class needs a metadataFields property
+    # for every action whose function body reads config.metadataFields.
+    create :register do
+      accept [:name]
+      metadata :registered_at, :utc_datetime
+    end
+  end
+end

--- a/test/support/test_domain.ex
+++ b/test/support/test_domain.ex
@@ -7,11 +7,18 @@ defmodule AshKotlinMultiplatform.Test.Domain do
   use Ash.Domain, extensions: [AshKotlinMultiplatform.Rpc]
 
   resources do
+    resource AshKotlinMultiplatform.Test.Event
     resource AshKotlinMultiplatform.Test.Todo
     resource AshKotlinMultiplatform.Test.User
   end
 
   kotlin_rpc do
+    resource AshKotlinMultiplatform.Test.Event do
+      rpc_action :list_events, :read
+      rpc_action :create_event, :create
+      rpc_action :register_event, :register
+    end
+
     resource AshKotlinMultiplatform.Test.Todo do
       rpc_action :list_todos, :read
       rpc_action :get_todo, :read


### PR DESCRIPTION
# PR description

## Summary

Two independent generator bugs found while generating an RPC client for a real
Kotlin Multiplatform consumer (`datetime_library: :kotlinx_datetime`, several
actions with `show_metadata`), diagnosed from the Kotlin compiler errors on
the generated output.

- **`Instant` fields have no serializer, across kotlinx-datetime versions.**
  kotlinx-datetime 0.7 deprecated `kotlinx.datetime.Instant` in favor of the
  stdlib's `kotlin.time.Instant` and dropped `Instant`'s default serializer
  (removing the concrete `InstantIso8601Serializer` object in the process) —
  so the generator's previously bare `val confirmedAt: kotlinx.datetime.Instant?
  = null` fails to compile against kotlinx-datetime >= 0.7.

  The first pass at this fix subclassed the replacement
  `FormattedInstantSerializer` — but that class doesn't exist before 0.7
  either, so it swapped one broken version range for another. Real-world
  testing against a consumer app still pinned to kotlinx-datetime 0.6.1
  caught this immediately (`Unresolved reference 'FormattedInstantSerializer'`).

  Fixed properly: `Instant` fields are emitted `@Contextual`, and
  `generate_http_client_factory/0` defines a hand-written
  `InstantIso8601Serializer : KSerializer<Instant>` built only on
  `Instant.toString()`/`Instant.parse()` — API stable across the 0.6 → 0.7
  transition, with no dependency on either version-specific serializer class
  — registered via `SerializersModule` on the generated `Json {}` config.
  `:java_time` is unaffected.

- **`metadataFields` referenced but never declared.** `payload_builder.ex`
  already emits `config.metadataFields?.let { ... }` in the generated
  function body for actions that expose metadata, but `config_builder.ex`
  never added a matching field to the `Config` data class it builds — so the
  generated code referenced an undeclared property. Fixed by reusing the
  exact same `MetadataTypes.metadata_enabled?/get_exposed_metadata_fields`
  check that `function_core.ex` uses, so the two generators can't drift
  apart again.

## Test plan

- [x] `mix compile` — clean
- [x] `mix test` — 48 tests, 2 pre-existing failures in `HelpersTest`
      (`snake_to_camel_case`/`camel_to_snake_case` edge cases) unrelated to
      this change
- [x] Regenerated via `mix ash_kotlin_multiplatform.codegen` against a real
      consumer app (`datetime_library: :kotlinx_datetime`, kotlinx-datetime
      0.6.1) by pointing its dependency at this branch, and confirmed a clean
      Kotlin build in Android Studio
- [x] Confirmed `metadataFields` correctly does *not* appear for actions with
      no exposed metadata (negative control — the consumer app used for
      verification has no `show_metadata` actions, so this fix's positive
      case wasn't exercised live, only through the generator's own logic)

