### PR TITLE
fix: route base filter types through TypeMapper for datetime_library

### DIFF
--- a/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
@@ -42,6 +42,7 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypes do
   """
 
   alias AshIntrospection.FieldFormatter
+  alias AshKotlinMultiplatform.Codegen.TypeMapper
 
   @doc """
   Generates filter types for multiple resources.
@@ -123,6 +124,13 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypes do
   These are the primitive filter types used by resource filters.
   """
   def generate_base_filter_types do
+    date_type = TypeMapper.get_kotlin_type_for_type(Ash.Type.Date)
+
+    instant_type =
+      TypeMapper.annotate_contextual_types(
+        TypeMapper.get_kotlin_type_for_type(Ash.Type.UtcDatetime)
+      )
+
     """
     @Serializable
     data class StringFilter(
@@ -172,26 +180,26 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypes do
 
     @Serializable
     data class DateFilter(
-        val eq: kotlinx.datetime.LocalDate? = null,
-        val notEq: kotlinx.datetime.LocalDate? = null,
-        val greaterThan: kotlinx.datetime.LocalDate? = null,
-        val greaterThanOrEqual: kotlinx.datetime.LocalDate? = null,
-        val lessThan: kotlinx.datetime.LocalDate? = null,
-        val lessThanOrEqual: kotlinx.datetime.LocalDate? = null,
+        val eq: #{date_type}? = null,
+        val notEq: #{date_type}? = null,
+        val greaterThan: #{date_type}? = null,
+        val greaterThanOrEqual: #{date_type}? = null,
+        val lessThan: #{date_type}? = null,
+        val lessThanOrEqual: #{date_type}? = null,
         @SerialName("in")
-        val inValues: List<kotlinx.datetime.LocalDate>? = null
+        val inValues: List<#{date_type}>? = null
     )
 
     @Serializable
     data class InstantFilter(
-        val eq: @Contextual kotlinx.datetime.Instant? = null,
-        val notEq: @Contextual kotlinx.datetime.Instant? = null,
-        val greaterThan: @Contextual kotlinx.datetime.Instant? = null,
-        val greaterThanOrEqual: @Contextual kotlinx.datetime.Instant? = null,
-        val lessThan: @Contextual kotlinx.datetime.Instant? = null,
-        val lessThanOrEqual: @Contextual kotlinx.datetime.Instant? = null,
+        val eq: #{instant_type}? = null,
+        val notEq: #{instant_type}? = null,
+        val greaterThan: #{instant_type}? = null,
+        val greaterThanOrEqual: #{instant_type}? = null,
+        val lessThan: #{instant_type}? = null,
+        val lessThanOrEqual: #{instant_type}? = null,
         @SerialName("in")
-        val inValues: List<@Contextual kotlinx.datetime.Instant>? = null
+        val inValues: List<#{instant_type}>? = null
     )
 
     @Serializable

--- a/test/ash_kotlin_multiplatform/codegen/filter_types_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/filter_types_test.exs
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Codegen.FilterTypesTest do
+  @moduledoc """
+  The base filter types (`DateFilter`, `InstantFilter`) must name whichever
+  datetime library `AshKotlinMultiplatform.datetime_library/0` selects, the
+  way every other emitter does. Before this fix they hardcoded
+  `kotlinx.datetime.*`, so a `:java_time` consumer got a filter block that
+  named a package it never imports (issue #11).
+  """
+  use ExUnit.Case, async: false
+
+  alias AshKotlinMultiplatform.Codegen.FilterTypes
+
+  defp put_datetime_library(library) do
+    previous = Application.get_env(:ash_kotlin_multiplatform, :datetime_library)
+    Application.put_env(:ash_kotlin_multiplatform, :datetime_library, library)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:ash_kotlin_multiplatform, :datetime_library)
+        value -> Application.put_env(:ash_kotlin_multiplatform, :datetime_library, value)
+      end
+    end)
+  end
+
+  describe "with datetime_library: :kotlinx_datetime" do
+    setup do
+      put_datetime_library(:kotlinx_datetime)
+      :ok
+    end
+
+    test "DateFilter names kotlinx.datetime.LocalDate" do
+      kotlin = FilterTypes.generate_base_filter_types()
+
+      assert kotlin =~ "val eq: kotlinx.datetime.LocalDate? = null"
+      assert kotlin =~ "val inValues: List<kotlinx.datetime.LocalDate>? = null"
+      refute kotlin =~ "java.time"
+    end
+
+    test "InstantFilter names kotlinx.datetime.Instant, annotated @Contextual" do
+      kotlin = FilterTypes.generate_base_filter_types()
+
+      assert kotlin =~ "val eq: @Contextual kotlinx.datetime.Instant? = null"
+      assert kotlin =~ "val inValues: List<@Contextual kotlinx.datetime.Instant>? = null"
+    end
+  end
+
+  describe "with datetime_library: :java_time" do
+    setup do
+      put_datetime_library(:java_time)
+      :ok
+    end
+
+    test "DateFilter names java.time.LocalDate" do
+      kotlin = FilterTypes.generate_base_filter_types()
+
+      assert kotlin =~ "val eq: java.time.LocalDate? = null"
+      assert kotlin =~ "val inValues: List<java.time.LocalDate>? = null"
+      refute kotlin =~ "kotlinx.datetime"
+    end
+
+    test "InstantFilter names java.time.Instant, left bare (no @Contextual)" do
+      kotlin = FilterTypes.generate_base_filter_types()
+
+      assert kotlin =~ "val eq: java.time.Instant? = null"
+      assert kotlin =~ "val inValues: List<java.time.Instant>? = null"
+      refute kotlin =~ "@Contextual"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`FilterTypes.generate_base_filter_types/0` wrote `kotlinx.datetime.LocalDate`
and `kotlinx.datetime.Instant` as literal strings, ignoring
`AshKotlinMultiplatform.datetime_library/0`. A `:java_time` consumer got a
generated file that imports `java.time.*` and then names a `kotlinx` type,
which does not resolve. Every other emitter already routes through
`TypeMapper`; this brings the filter types in line.

Closes #11

## Changes

- `DateFilter` and `InstantFilter` now call
  `TypeMapper.get_kotlin_type_for_type/2` for their field types, so they
  follow `datetime_library` like every other emitter.
- `InstantFilter`'s type also goes through
  `TypeMapper.annotate_contextual_types/1`, so `kotlinx.datetime.Instant`
  keeps the `@Contextual` annotation PR #10 added, while `java.time.Instant`
  stays bare (that helper already leaves it alone).

## Reasoning

`TypeMapper.map_type/2` switches on `datetime_library` for every date/time
Ash type, but `FilterTypes` had its own heredoc with the `kotlinx` names
baked in. Filter types only generate when `with_filters` is on, which is why
this shipped unnoticed. There was nothing else to fix: `Ash.Type.Time` has no
dedicated filter (falls through to `StringFilter`), and `NaiveDatetime`/
`DateTime` already share `InstantFilter` with `UtcDatetime`, so no separate
`LocalDateTime` filter exists to hardcode.

## Test plan

New `test/ash_kotlin_multiplatform/codegen/filter_types_test.exs`, written
before the fix and confirmed failing against the old code:

```
$ mix test test/ash_kotlin_multiplatform/codegen/filter_types_test.exs
4 tests, 2 failures   # before the fix
4 tests, 0 failures   # after the fix
```

It asserts `DateFilter`/`InstantFilter` name `kotlinx.datetime.*` under
`:kotlinx_datetime` and `java.time.*` under `:java_time`, and that
`@Contextual` appears only on the kotlinx `Instant`.

The existing `InstantSerializationTest` guard (added in PR #10) stays green:

```
$ mix test test/ash_kotlin_multiplatform/codegen/instant_serialization_test.exs
9 tests, 0 failures
```

Full suite:

```
$ mix test
70 tests, 2 failures
```

The 2 failures are pre-existing, unrelated `HelpersTest` cases
(`camel_to_snake_case("XMLParser")`, `snake_to_camel_case("_private_field")`)
that predate this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQTWtSeg8sdQPJLV7zAD9e