### PR TITLE
fix: honor the metadataFields the generated client sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `Rpc.Runner` now honors the `metadataFields` param the generated Kotlin
+  client sends. It narrows the metadata fields the DSL exposes and can never
+  widen them: a field the DSL withholds is not returned and raises no error.
+  Absent or `null` returns everything the DSL exposes, as before; `[]` returns
+  no metadata.
+
 ## [0.1.3] - 2025-12-21
 
 ### Changed
@@ -25,16 +33,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed GitHub URLs to point to correct repository (udin-io/ash_kotlin_multiplatform)
+- Fixed GitHub URLs to point to correct repository
+  (udin-io/ash_kotlin_multiplatform)
 
 ## [0.1.0] - 2025-12-21
 
-> **Alpha Release** - This is an early alpha release. The API may change between versions.
+> **Alpha Release** - This is an early alpha release. The API may change
+> between versions.
 
 ### Added
 
 - Initial release of AshKotlinMultiplatform
-- `AshKotlinMultiplatform.Resource` extension for resource-level Kotlin configuration
+- `AshKotlinMultiplatform.Resource` extension for resource-level Kotlin
+  configuration
   - `type_name` option for custom Kotlin class names
   - `field_names` option for mapping field names to valid Kotlin identifiers
   - `argument_names` option for mapping action argument names

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,3 +6,9 @@ import Config
 
 # Configure Ash to not validate domain config inclusion in tests
 config :ash, :validate_domain_config_inclusion?, false
+
+# Rpc.Runner discovers actions through Ash.Info.domains/1, which reads this key.
+# Test-only: shipping a test domain in the library's own app config would be a bug.
+if config_env() == :test do
+  config :ash_kotlin_multiplatform, ash_domains: [AshKotlinMultiplatform.Test.Domain]
+end

--- a/lib/ash_kotlin_multiplatform/rpc/runner.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/runner.ex
@@ -129,7 +129,8 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
     action_info = Ash.Resource.Info.action(resource, action_name)
 
     # Build the request
-    request = build_request(domain, resource, action_info, rpc_action, params, actor, tenant, context)
+    request =
+      build_request(domain, resource, action_info, rpc_action, params, actor, tenant, context)
 
     # Execute through the pipeline
     with {:ok, ash_result} <- Pipeline.execute_ash_action(request),
@@ -163,9 +164,15 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
         nil ->
           # nil means "show all" - get all metadata fields from action
           get_action_metadata_fields(action)
-        false -> []
-        list when is_list(list) -> list
-        _ -> []
+
+        false ->
+          []
+
+        list when is_list(list) ->
+          list
+
+        _ ->
+          []
       end
 
     %Request{
@@ -207,6 +214,7 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
 
         :update ->
           identity = parse_identity(params)
+
           with {:ok, record} <- get_record_for_validation(resource, identity, opts) do
             changeset = Ash.Changeset.for_update(record, action_name, input, opts)
             {:ok, changeset}
@@ -224,11 +232,16 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
         build_validation_error_response(errors)
 
       {:error, :validation_not_supported} ->
-        %{"success" => false, "errors" => [%{
-          "type" => "unsupported",
-          "message" => "Validation is only supported for create and update actions",
-          "shortMessage" => "Unsupported"
-        }]}
+        %{
+          "success" => false,
+          "errors" => [
+            %{
+              "type" => "unsupported",
+              "message" => "Validation is only supported for create and update actions",
+              "shortMessage" => "Unsupported"
+            }
+          ]
+        }
 
       {:error, error} ->
         build_error_response(error)
@@ -246,7 +259,9 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
   # Get all metadata field names from an action
   defp get_action_metadata_fields(action) do
     case Map.get(action, :metadata) do
-      nil -> []
+      nil ->
+        []
+
       metadata when is_list(metadata) ->
         Enum.map(metadata, fn
           %{name: name} -> name
@@ -255,7 +270,9 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
           _ -> nil
         end)
         |> Enum.reject(&is_nil/1)
-      _ -> []
+
+      _ ->
+        []
     end
   end
 

--- a/lib/ash_kotlin_multiplatform/rpc/runner.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/runner.ex
@@ -27,6 +27,9 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
   - `"filter"` - Filter for read actions
   - `"sort"` - Sort string for read actions
   - `"page"` - Pagination options
+  - `"metadataFields"` - Metadata fields to return. Narrows the fields the DSL
+    exposes; it can never widen them. Absent or `nil` returns every exposed
+    field, `[]` returns none.
 
   ## Response Format
 
@@ -156,24 +159,10 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
     extraction_template = build_extraction_template(resource, fields)
     {select, load} = build_select_and_load(resource, fields)
 
-    # Get show_metadata, ensuring it's always a list
-    # nil in DSL means "show all", but for the pipeline we need a list
-    # false or [] means "show none", a list means "show specific fields"
     show_metadata =
-      case Map.get(rpc_action, :show_metadata) do
-        nil ->
-          # nil means "show all" - get all metadata fields from action
-          get_action_metadata_fields(action)
-
-        false ->
-          []
-
-        list when is_list(list) ->
-          list
-
-        _ ->
-          []
-      end
+      action
+      |> dsl_metadata_fields(rpc_action)
+      |> narrow_metadata_fields(parse_metadata_fields(params))
 
     %Request{
       domain: domain,
@@ -256,8 +245,32 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
     {:error, {:missing_required_parameter, :identity}}
   end
 
+  # ---------------------------------------------------------------------------
+  # Metadata Field Selection
+  # ---------------------------------------------------------------------------
+
+  # What the DSL exposes: nil means every field the action declares, false or []
+  # means none, a list means exactly that list.
+  defp dsl_metadata_fields(action, rpc_action) do
+    case Map.get(rpc_action, :show_metadata) do
+      nil -> action_metadata_fields(action)
+      false -> []
+      list when is_list(list) -> list
+      _ -> []
+    end
+  end
+
+  # The client can only narrow, never widen. Filtering the DSL list means a name
+  # the DSL withholds yields nothing and no error that would reveal it exists.
+  # nil means the client asked for nothing in particular, so it gets everything.
+  defp narrow_metadata_fields(dsl_fields, nil), do: dsl_fields
+
+  defp narrow_metadata_fields(dsl_fields, requested) do
+    Enum.filter(dsl_fields, &(&1 in requested))
+  end
+
   # Get all metadata field names from an action
-  defp get_action_metadata_fields(action) do
+  defp action_metadata_fields(action) do
     case Map.get(action, :metadata) do
       nil ->
         []
@@ -316,6 +329,27 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
     end
   end
 
+  # nil means the client sent nothing, which keeps today's behaviour: everything
+  # the DSL exposes. An empty list means no metadata.
+  defp parse_metadata_fields(params) do
+    case params["metadataFields"] do
+      fields when is_list(fields) -> Enum.flat_map(fields, &existing_metadata_atom/1)
+      _ -> nil
+    end
+  end
+
+  # String.to_existing_atom/1 stops a client from growing the atom table. A name
+  # that does not resolve is dropped rather than raised on: an atom that does not
+  # exist cannot name a metadata field either, so there is nothing to report.
+  defp existing_metadata_atom(name) when is_binary(name) do
+    [name |> to_snake_case() |> String.to_existing_atom()]
+  rescue
+    ArgumentError -> []
+  end
+
+  defp existing_metadata_atom(name) when is_atom(name) and not is_nil(name), do: [name]
+  defp existing_metadata_atom(_), do: []
+
   defp convert_keys_to_atoms(map) when is_map(map) do
     Map.new(map, fn
       {key, value} when is_binary(key) ->
@@ -335,9 +369,14 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
 
   defp to_snake_case_atom(string) when is_binary(string) do
     string
+    |> to_snake_case()
+    |> String.to_atom()
+  end
+
+  defp to_snake_case(string) when is_binary(string) do
+    string
     |> String.replace(~r/([a-z])([A-Z])/, "\\1_\\2")
     |> String.downcase()
-    |> String.to_atom()
   end
 
   # ---------------------------------------------------------------------------

--- a/test/ash_kotlin_multiplatform/rpc/runner_metadata_fields_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/runner_metadata_fields_test.exs
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.RunnerMetadataFieldsTest do
+  @moduledoc """
+  The generated Kotlin client sends `metadataFields`; the server must honor it.
+
+  The invariant under test: the client can only narrow. Whatever it asks for is
+  intersected with the fields the DSL exposes, so a name the DSL withholds
+  yields nothing and no error that would reveal the field exists.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Rpc.Runner
+
+  # `register_event` exposes both metadata fields; `register_event_narrow`
+  # exposes only `registered_at`. Both run the same `:register` action, which
+  # sets both fields to fixed values.
+  defp register(action, params \\ %{}) do
+    Runner.run_action(
+      :ash_kotlin_multiplatform,
+      Map.merge(%{"action" => action, "input" => %{"name" => "Launch"}}, params)
+    )
+  end
+
+  defp metadata(response) do
+    assert %{"success" => true, "data" => data} = response
+    Map.get(data, "metadata", %{})
+  end
+
+  test "a subset request returns exactly that subset" do
+    metadata = metadata(register("register_event", %{"metadataFields" => ["registeredAt"]}))
+
+    assert metadata == %{"registeredAt" => ~U[2026-01-01 00:00:00Z]}
+  end
+
+  test "snake_case names work as well as the camelCase the client sends" do
+    metadata = metadata(register("register_event", %{"metadataFields" => ["registered_at"]}))
+
+    assert metadata == %{"registeredAt" => ~U[2026-01-01 00:00:00Z]}
+  end
+
+  test "a field the DSL does not expose is withheld and the request still succeeds" do
+    response =
+      register("register_event_narrow", %{
+        "metadataFields" => ["registeredAt", "confirmationCode"]
+      })
+
+    assert %{"success" => true} = response
+    assert metadata(response) == %{"registeredAt" => ~U[2026-01-01 00:00:00Z]}
+  end
+
+  test "an attribute name is not a way to smuggle out extra metadata" do
+    response = register("register_event", %{"metadataFields" => ["id"]})
+
+    assert %{"success" => true} = response
+    assert metadata(response) == %{}
+  end
+
+  test "an empty list returns no metadata" do
+    response = register("register_event", %{"metadataFields" => []})
+
+    assert %{"success" => true} = response
+    assert metadata(response) == %{}
+  end
+
+  test "an absent param returns everything the DSL exposes" do
+    assert metadata(register("register_event")) == %{
+             "registeredAt" => ~U[2026-01-01 00:00:00Z],
+             "confirmationCode" => "AKM-1"
+           }
+  end
+
+  test "a nil param returns everything the DSL exposes" do
+    assert metadata(register("register_event", %{"metadataFields" => nil})) == %{
+             "registeredAt" => ~U[2026-01-01 00:00:00Z],
+             "confirmationCode" => "AKM-1"
+           }
+  end
+
+  test "a name that is not an existing atom is dropped rather than crashing" do
+    response =
+      register("register_event", %{
+        "metadataFields" => ["registeredAt", "no_such_metadata_field_anywhere"]
+      })
+
+    assert %{"success" => true} = response
+    assert metadata(response) == %{"registeredAt" => ~U[2026-01-01 00:00:00Z]}
+  end
+
+  test "a garbage name does not grow the atom table" do
+    register("register_event", %{"metadataFields" => ["definitely_not_an_atom_yet_9f3a"]})
+
+    assert_raise ArgumentError, fn ->
+      String.to_existing_atom("definitely_not_an_atom_yet_9f3a")
+    end
+  end
+end

--- a/test/support/resources/event.ex
+++ b/test/support/resources/event.ex
@@ -41,10 +41,19 @@ defmodule AshKotlinMultiplatform.Test.Event do
     end
 
     # Exercises the metadata path: the Config class needs a metadataFields property
-    # for every action whose function body reads config.metadataFields.
+    # for every action whose function body reads config.metadataFields. Two fields,
+    # both with fixed values, so a test can assert on a proper subset.
     create :register do
       accept [:name]
       metadata :registered_at, :utc_datetime
+      metadata :confirmation_code, :string
+
+      change after_action(fn _changeset, record, _context ->
+               {:ok,
+                record
+                |> Ash.Resource.put_metadata(:registered_at, ~U[2026-01-01 00:00:00Z])
+                |> Ash.Resource.put_metadata(:confirmation_code, "AKM-1")}
+             end)
     end
   end
 end

--- a/test/support/test_domain.ex
+++ b/test/support/test_domain.ex
@@ -17,6 +17,12 @@ defmodule AshKotlinMultiplatform.Test.Domain do
       rpc_action :list_events, :read
       rpc_action :create_event, :create
       rpc_action :register_event, :register
+
+      # Exposes one of the action's two metadata fields, so a test can prove a
+      # client cannot widen past what the DSL allows.
+      rpc_action :register_event_narrow, :register do
+        show_metadata [:registered_at]
+      end
     end
 
     resource AshKotlinMultiplatform.Test.Todo do


### PR DESCRIPTION
Closes #12

## Summary

The generated Kotlin client has been sending a `metadataFields` param for every
action that exposes metadata. `Rpc.Runner` threw it away: `show_metadata` came
from the DSL alone, so a client asking for one metadata field got all of them.
The wire format promised sparse selection and did not deliver it.

This makes the server read the param.

## The narrowing invariant

**The client can only narrow, never widen.** The requested list is intersected
with the fields the DSL exposes:

- A field the DSL exposes and the client asks for is returned.
- A field the DSL exposes and the client does not ask for is withheld.
- A field the DSL does **not** expose is withheld no matter what the client
  asks, and the request still succeeds. No error, because an error would tell
  the client the field exists.
- Absent or `null` means everything the DSL exposes. That is today's behaviour,
  so existing consumers do not change.
- `[]` means no metadata.

Implemented as `Enum.filter(dsl_fields, &(&1 in requested))` in
`narrow_metadata_fields/2`, so the DSL list is always the ceiling.

## Reasoning

Names arrive from JSON as strings, so they go through `String.to_existing_atom/1`
(after the same camelCase to snake_case conversion the `fields` param already
uses, since the generated Kotlin properties are camelCase). A name that does not
resolve is dropped rather than raised on: an atom that does not exist cannot
name a metadata field either, and raising would let a client both grow nothing
useful and probe for which names are real.

The parsing sits next to `parse_filter`, `parse_sort` and `parse_pagination` and
feeds the existing `%Request{}` field. Nothing downstream changed —
`AshIntrospection.Rpc.Pipeline.extract_metadata_fields/2` already builds its
output from `request.show_metadata`, which is exactly why narrowing had to
happen at the boundary: that function does a plain `Map.get`, so an unexposed
name would otherwise have come back as an explicit `null` key and leaked that
the server accepted it.

`get_action_metadata_fields/1` was renamed `action_metadata_fields/1` and the
DSL branch split into `dsl_metadata_fields/2`, so the two decisions — what the
DSL exposes, what the client narrowed it to — read as two steps.

## Test support

`Rpc.Runner.run_action/3` had no tests at all, and could not have any: nothing
registered the test domain under `:ash_kotlin_multiplatform`, so
`Ash.Info.domains/1` returned `[]`. `config/config.exs` now registers it under
`if config_env() == :test`.

The `:register` action on the `Event` fixture declared one metadata field and
never set it, so every value came back `nil`. It now declares two, both set to
fixed values by an `after_action` change, so a test can assert on a proper
subset. `:register_event_narrow` exposes only one of the two via
`show_metadata [:registered_at]`, which is what proves the client cannot widen.

## Test plan

New file: `test/ash_kotlin_multiplatform/rpc/runner_metadata_fields_test.exs`,
9 tests driven through `Runner.run_action/3` — the public entry point, asserting
on the response map, not on internal state.

Covering every case in the issue:

| Case | Test |
| --- | --- |
| Subset requested | returns exactly `registeredAt` |
| Field the DSL does not expose | withheld, request succeeds |
| An attribute name (`id`) smuggled in | withheld, request succeeds |
| `[]` | no metadata |
| Absent | both fields (no regression) |
| Explicit `null` | both fields |
| Name that is not an existing atom | dropped, request succeeds |
| Garbage name | `String.to_existing_atom/1` still raises for it afterwards |

Plus one for snake_case names, since the client sends camelCase but the param is
hand-writable.

**Before the fix** — `mix test test/ash_kotlin_multiplatform/rpc/runner_metadata_fields_test.exs`:

```
9 tests, 5 failures
```

The five failures all showed the same thing, e.g. for `metadataFields: []`:

```
left:  %{"confirmationCode" => "AKM-1", "registeredAt" => ~U[2026-01-01 00:00:00Z]}
right: %{}
```

**After the fix** — same command:

```
9 tests, 0 failures
```

**Full suite** — `mix test` after `mix compile --force`:

```
75 tests, 2 failures
```

The 2 failures are the pre-existing ones in
`test/ash_kotlin_multiplatform/helpers_test.exs`
(`camel_to_snake_case("XMLParser")` and `snake_to_camel_case("_private_field")`).
They are on `main` too and untouched here.

No compiler warnings.

## Commits

Four, in order: test scaffolding, a formatting-only `mix format` of
`runner.ex` (split out so the behaviour diff is only the narrowing), the fix
with its tests, and the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQTWtSeg8sdQPJLV7zAD9e
