### PR TITLE
ci: add GitHub Actions workflow (compile, test, dependency audit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  MIX_ENV: test
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          elixir-version: "1.18.4"
+
+      - name: Restore deps and _build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Compile (warnings as errors)
+        run: mix compile --warnings-as-errors
+
+      - name: Run tests
+        run: mix test
+
+      - name: Audit retired Hex packages
+        run: mix hex.audit
+
+      - name: Audit dependencies for known vulnerabilities
+        run: mix deps.audit

--- a/test/ash_kotlin_multiplatform/helpers_test.exs
+++ b/test/ash_kotlin_multiplatform/helpers_test.exs
@@ -21,8 +21,10 @@ defmodule AshKotlinMultiplatform.HelpersTest do
     end
 
     test "handles leading underscore" do
-      # Leading underscores cause first segment to be capitalized
-      assert Helpers.snake_to_camel_case("_private_field") == "PrivateField"
+      # snake_to_camel_case always lowercases the first character, even when
+      # the leading underscore makes Macro.camelize/1 capitalize the segment
+      # that follows it. camelCase output stays camelCase (see #36).
+      assert Helpers.snake_to_camel_case("_private_field") == "privateField"
     end
   end
 
@@ -50,8 +52,10 @@ defmodule AshKotlinMultiplatform.HelpersTest do
     end
 
     test "handles consecutive capitals" do
-      # Consecutive capitals are lowercased together
-      assert Helpers.camel_to_snake_case("XMLParser") == "xmlparser"
+      # Macro.underscore/1 treats a run of capitals as one acronym segment
+      # and splits before the capital that starts the next word, same as
+      # the HelloWorld case above (see #36).
+      assert Helpers.camel_to_snake_case("XMLParser") == "xml_parser"
     end
   end
 end


### PR DESCRIPTION
Closes #21.

## Summary

- Adds `.github/workflows/ci.yml`, running on push to `main` and on
  pull requests: `mix deps.get`, `mix compile --warnings-as-errors`,
  `mix test`, `mix hex.audit`, `mix deps.audit`.
- Uses `erlef/setup-beam@v1` pinned to OTP 27 / Elixir 1.18.4 - what's
  actually installed and in use locally (no `mise.toml` or
  `.tool-versions` exists anywhere in this repo or its parent to pin
  against instead).
- Caches `deps/` and `_build/` keyed on `mix.lock`'s hash.
- Fixes #36: both `helpers_test.exs` failures were wrong test
  expectations, not code bugs. `snake_to_camel_case("_private_field")`
  correctly returns `"privateField"` (camelCase always lowercases the
  first char); `camel_to_snake_case("XMLParser")` correctly returns
  `"xml_parser"` (`Macro.underscore/1` treats a capital run as one
  acronym segment, same rule the passing `"HelloWorld"` case in the
  same block already relies on). Both functions live in the
  `ash_introspection` dependency, not this repo, and match their
  documented doctests.
- Adds `{:mix_audit, ">= 0.0.0", only: [:dev, :test], runtime: false}`
  to `mix.exs` - it was not a dependency before this PR, and
  `mix deps.audit` needs it. (#42 added the same line while this PR
  was open; rebasing kept one copy.)

## Not included, and why

- **`mix format --check-formatted`**: the tree is not formatter-clean
  (13 files, unrelated to this PR). Filed as #38 rather than sweeping
  formatting into a CI PR.
- **Compiling the generated Kotlin with `kotlinc`**: the codegen
  invocation already works (`MIX_ENV=test mix
  ash_kotlin_multiplatform.codegen` produced a valid 1752-line
  `AshRpc.kt` from the test fixtures), but the output isn't
  self-contained - it needs `kotlinx-serialization`, `kotlinx-datetime`,
  `ktor-client-*`, and `kotlinx-coroutines` resolved from Maven Central,
  which means a real Gradle fixture project plus a JDK/Kotlin toolchain
  in CI. That's a bigger, separate piece of work - filed as #37 with
  what was learned about its shape (a plain `kotlin("jvm")` module may
  be enough; no `expect`/`actual` appeared in the fixture output).

## Status: all five steps green

This PR's first CI run was red on `mix hex.audit` (33 advisories across
7 packages, live registry data; local `mix hex.audit` reported clean
against a stale cache - the failure mode #21 called out). #39 tracked
fixing it; it merged as #42, raising the `ash`, `ash_phoenix`,
`phoenix`, `plug`, and `spark` floors past every advisory.

This branch is now rebased onto `main` (`f10f744`, includes #42). The
same conflict `mix_audit` line: kept one copy in `mix.exs`,
regenerated `mix.lock` with `mix deps.get`. Latest run, all steps
green:
https://github.com/udin-io/ash_kotlin_multiplatform/actions/runs/34386891540

## Test plan

Real per-step results, both local (informational - local `hex.audit`
reads a cached registry and is not authoritative, see above) and from
the CI run linked above (authoritative):

- `mix deps.get` - resolves cleanly.
- `mix compile --warnings-as-errors` - no warnings.
- `mix test` - **79 tests, 0 failures**.
- `mix hex.audit` - **"No retired or security advisory packages
  found"** in CI (live data). Locally reports the same, but only
  because of a stale cache - CI's result is the one that counts.
- `mix deps.audit` - **"No vulnerabilities found."** in CI, matching
  local.
