### PR TITLE
fix: generated Kotlin compiles for map, union and unmapped types

### DIFF
--- a/lib/ash_kotlin_multiplatform.ex
+++ b/lib/ash_kotlin_multiplatform.ex
@@ -51,10 +51,22 @@ defmodule AshKotlinMultiplatform do
   @doc """
   Returns the Kotlin type to use for untyped maps.
 
-  Defaults to "Map<String, Any?>".
+  Defaults to `"Map<String, @Contextual Any?>"`. The annotation is load-bearing:
+  an untyped map lands in `@Serializable` data class fields, kotlinx-serialization
+  has no serializer for `Any`, and a bare `Map<String, Any?>` there fails to
+  compile with "Serializer has not been found for type 'Any?'". `@Contextual`
+  defers the lookup to the `SerializersModule`.
+
+  A configured override need not carry the annotation —
+  `AshKotlinMultiplatform.Codegen.TypeMapper.annotate_contextual_types/1` adds it
+  on the way into a serializable field.
   """
   def untyped_map_type do
-    Application.get_env(:ash_kotlin_multiplatform, :untyped_map_type, "Map<String, Any?>")
+    Application.get_env(
+      :ash_kotlin_multiplatform,
+      :untyped_map_type,
+      "Map<String, @Contextual Any?>"
+    )
   end
 
   @doc """

--- a/lib/ash_kotlin_multiplatform.ex
+++ b/lib/ash_kotlin_multiplatform.ex
@@ -60,6 +60,13 @@ defmodule AshKotlinMultiplatform do
   A configured override need not carry the annotation —
   `AshKotlinMultiplatform.Codegen.TypeMapper.annotate_contextual_types/1` adds it
   on the way into a serializable field.
+
+  `@Contextual` fixes compilation, not decoding. A field holding an actual map
+  still throws `SerializationException: Serializer for class 'Any' is not found`
+  unless the consumer registers a serializer for `Any` on the `SerializersModule`
+  (verified against kotlinx-serialization 1.9.0; `null` and absent values decode
+  fine without one). Configure this option to a concrete Kotlin type when the map
+  has a known shape.
   """
   def untyped_map_type do
     Application.get_env(

--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -82,39 +82,34 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
     type = attr.type
     constraints = attr.constraints || []
 
-    {enums, unions, embedded} =
-      case type do
-        Ash.Type.Atom ->
-          case Keyword.get(constraints, :one_of) do
-            nil ->
-              {enums, unions, embedded}
+    # Shares its predicates with `field_kotlin_type/1`: whatever gets a class here
+    # is exactly what a field is allowed to name, so the two cannot drift into
+    # orphaned classes or dangling references.
+    cond do
+      TypeMapper.is_enum_type?(type, constraints) ->
+        enum_name = generate_enum_name(attr.name)
+        {[{enum_name, TypeMapper.get_enum_values(constraints)} | enums], unions, embedded}
 
-            values ->
-              enum_name = generate_enum_name(attr.name)
-              {[{enum_name, values} | enums], unions, embedded}
-          end
+      TypeMapper.is_union_type?(type) ->
+        union_types = Introspection.get_union_types_from_constraints(type, constraints)
+        union_name = generate_union_name(attr.name)
+        {enums, [{union_name, union_types} | unions], embedded}
 
-        Ash.Type.Union ->
-          union_types = Introspection.get_union_types_from_constraints(type, constraints)
-          union_name = generate_union_name(attr.name)
-          {enums, [{union_name, union_types} | unions], embedded}
+      true ->
+        {enums, unions, collect_embedded_resource(type, embedded)}
+    end
+  end
 
-        {:array, inner_type} ->
-          if Introspection.is_embedded_resource?(inner_type) do
-            {enums, unions, MapSet.put(embedded, inner_type)}
-          else
-            {enums, unions, embedded}
-          end
+  defp collect_embedded_resource({:array, inner_type}, embedded) do
+    collect_embedded_resource(inner_type, embedded)
+  end
 
-        _ ->
-          if Introspection.is_embedded_resource?(type) do
-            {enums, unions, MapSet.put(embedded, type)}
-          else
-            {enums, unions, embedded}
-          end
-      end
-
-    {enums, unions, embedded}
+  defp collect_embedded_resource(type, embedded) do
+    if Introspection.is_embedded_resource?(type) do
+      MapSet.put(embedded, type)
+    else
+      embedded
+    end
   end
 
   @doc """
@@ -193,20 +188,28 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
   end
 
   # A union attribute has a sealed class generated for it by `collect_types/1`, and
-  # the field has to name that class or the class is emitted and referenced by
-  # nothing. `TypeMapper` cannot supply the name: it maps from the Ash type alone,
-  # while the class name comes from the attribute name.
+  # a `one_of` atom attribute an enum class; the field has to name that class or
+  # the class is emitted and referenced by nothing. `TypeMapper` cannot supply the
+  # name: it maps from the Ash type alone, while both names come from the attribute
+  # name.
   #
   # Both `collect_types/1` and `generate_data_class/1` read
-  # `Ash.Resource.Info.public_attributes/1`, so the class a field names always
-  # exists. Nothing else may take this branch — a union reached through an action
-  # argument or a union member has no generated class, and naming one there would
-  # emit a dangling reference.
+  # `Ash.Resource.Info.public_attributes/1` and share the predicates below, so the
+  # class a field names always exists. Nothing else may take these branches — a
+  # union or `one_of` atom reached through an action argument or a union member has
+  # no generated class, and naming one there would emit a dangling reference.
   defp field_kotlin_type(attribute) do
-    if TypeMapper.is_union_type?(attribute.type) do
-      nullable_class_name(generate_union_name(attribute.name), attribute)
-    else
-      TypeMapper.get_kotlin_type(attribute)
+    constraints = attribute.constraints || []
+
+    cond do
+      TypeMapper.is_union_type?(attribute.type) ->
+        nullable_class_name(generate_union_name(attribute.name), attribute)
+
+      TypeMapper.is_enum_type?(attribute.type, constraints) ->
+        nullable_class_name(generate_enum_name(attribute.name), attribute)
+
+      true ->
+        TypeMapper.get_kotlin_type(attribute)
     end
   end
 

--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -86,7 +86,9 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
       case type do
         Ash.Type.Atom ->
           case Keyword.get(constraints, :one_of) do
-            nil -> {enums, unions, embedded}
+            nil ->
+              {enums, unions, embedded}
+
             values ->
               enum_name = generate_enum_name(attr.name)
               {[{enum_name, values} | enums], unions, embedded}
@@ -283,18 +285,22 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
       case member_type do
         Ash.Type.Map ->
           case Keyword.get(member_constraints, :fields) do
-            nil -> "val value: Map<String, Any?>"
+            nil -> "val value: #{untyped_map_type()}"
             field_specs -> generate_union_fields(field_specs)
           end
 
         Ash.Type.Struct ->
           case Keyword.get(member_constraints, :instance_of) do
-            nil -> "val value: Map<String, Any?>"
+            nil -> "val value: #{untyped_map_type()}"
             module -> "val value: #{TypeMapper.get_kotlin_class_name(module)}"
           end
 
         _ ->
-          kotlin_type = TypeMapper.get_kotlin_type_for_type(member_type, member_constraints)
+          kotlin_type =
+            member_type
+            |> TypeMapper.get_kotlin_type_for_type(member_constraints)
+            |> TypeMapper.annotate_contextual_types()
+
           "val value: #{kotlin_type}"
       end
 
@@ -314,7 +320,11 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
       field_constraints = Keyword.get(field_config, :constraints, [])
       allow_nil = Keyword.get(field_config, :allow_nil?, true)
 
-      kotlin_type = TypeMapper.get_kotlin_type_for_type(field_type, field_constraints)
+      kotlin_type =
+        field_type
+        |> TypeMapper.get_kotlin_type_for_type(field_constraints)
+        |> TypeMapper.annotate_contextual_types()
+
       kotlin_type = if allow_nil, do: "#{kotlin_type}?", else: kotlin_type
 
       formatted_name = format_field_name(field_name)
@@ -328,6 +338,11 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
       "#{serial_name}val #{formatted_name}: #{kotlin_type}#{default}"
     end)
     |> Enum.join(",\n            ")
+  end
+
+  defp untyped_map_type do
+    AshKotlinMultiplatform.untyped_map_type()
+    |> TypeMapper.annotate_contextual_types()
   end
 
   defp generate_enum_name(attr_name) do

--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -161,7 +161,7 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
   end
 
   defp generate_field(attribute) do
-    kotlin_type = TypeMapper.get_kotlin_type(attribute)
+    kotlin_type = field_kotlin_type(attribute)
     field_name = format_field_name(attribute.name)
     original_name = Atom.to_string(attribute.name)
 
@@ -191,6 +191,27 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
 
     "#{serial_name}val #{field_name}: #{TypeMapper.annotate_contextual_types(kotlin_type)}#{default}"
   end
+
+  # A union attribute has a sealed class generated for it by `collect_types/1`, and
+  # the field has to name that class or the class is emitted and referenced by
+  # nothing. `TypeMapper` cannot supply the name: it maps from the Ash type alone,
+  # while the class name comes from the attribute name.
+  #
+  # Both `collect_types/1` and `generate_data_class/1` read
+  # `Ash.Resource.Info.public_attributes/1`, so the class a field names always
+  # exists. Nothing else may take this branch — a union reached through an action
+  # argument or a union member has no generated class, and naming one there would
+  # emit a dangling reference.
+  defp field_kotlin_type(attribute) do
+    if TypeMapper.is_union_type?(attribute.type) do
+      nullable_class_name(generate_union_name(attribute.name), attribute)
+    else
+      TypeMapper.get_kotlin_type(attribute)
+    end
+  end
+
+  defp nullable_class_name(class_name, %{allow_nil?: true}), do: "#{class_name}?"
+  defp nullable_class_name(class_name, _attribute), do: class_name
 
   defp make_nullable(kotlin_type) do
     if String.ends_with?(kotlin_type, "?") do

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -18,7 +18,7 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   alias AshIntrospection.TypeSystem.Introspection
 
   # Kotlin types with no serializer the compiler can resolve on its own.
-  @contextual_types ["kotlinx.datetime.Instant"]
+  @contextual_types ["kotlinx.datetime.Instant", "Any"]
 
   @doc """
   Returns the Kotlin type for an Ash attribute.
@@ -61,13 +61,22 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   @doc """
   Annotates the types that have no compile-time serializer with `@Contextual`.
 
-  `kotlinx.datetime.Instant` is the only such type. kotlinx-datetime 0.6 shipped a
-  default serializer for it; 0.7 deprecated the class in favour of
-  `kotlin.time.Instant` and dropped both the default and the concrete
-  `InstantIso8601Serializer` object. A generated file cannot know which version the
-  consumer pinned, so it defers the lookup to the `SerializersModule` that
+  Two types need it.
+
+  `kotlinx.datetime.Instant`: kotlinx-datetime 0.6 shipped a default serializer for
+  it; 0.7 deprecated the class in favour of `kotlin.time.Instant` and dropped both
+  the default and the concrete `InstantIso8601Serializer` object. A generated file
+  cannot know which version the consumer pinned, so it defers the lookup to the
+  `SerializersModule` that
   `AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic.generate_http_client_factory/0`
   registers.
+
+  `Any`: the landing type for untyped maps, keywords, tuples, unions and every Ash
+  type the mapper has no case for. kotlinx-serialization has no serializer for
+  `Any` and never will, so a bare `Any` inside a `@Serializable` class is a compile
+  error — "Serializer has not been found for type 'Any'" — not a runtime one.
+  `@Contextual` turns it into a `SerializersModule` lookup, which is the same
+  trade `ConfigBuilder` already makes for its `filter` and `page` maps.
 
   Annotates in type position rather than on the property, so element types resolve
   too: `List<@Contextual Instant>` consults the module for `Instant`, while
@@ -75,7 +84,9 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   `List<Instant>` and fail at runtime.
 
   `java.time.Instant` is left alone — `:java_time` consumers supply their own
-  serializers. Idempotent, so it is safe to apply to an already-annotated type.
+  serializers. Matches whole words only, so `Any` does not touch `AnyOf` or a
+  resource named `Anything`. Idempotent, so it is safe to apply to an
+  already-annotated type.
   """
   def annotate_contextual_types(kotlin_type) when is_binary(kotlin_type) do
     Enum.reduce(@contextual_types, kotlin_type, fn type, acc ->
@@ -186,15 +197,18 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   # Tuple type
   defp map_type(Ash.Type.Tuple, constraints) do
     case Keyword.get(constraints, :fields) do
-      nil -> "List<Any?>"
-      _fields -> "List<Any?>"
+      nil -> "List<@Contextual Any?>"
+      _fields -> "List<@Contextual Any?>"
     end
   end
 
-  # Union type - will be handled as sealed class
+  # Union type. A resource attribute gets the sealed class generated for it by
+  # `AshKotlinMultiplatform.Codegen.ResourceSchemas` — that lookup needs the
+  # attribute name, which this function does not have. Everywhere else (union
+  # member fields, action metadata, identity types) there is no such class, so the
+  # union falls back to a contextual `Any`.
   defp map_type(Ash.Type.Union, _constraints) do
-    # Union types are generated as sealed classes separately
-    "Any"
+    "@Contextual Any"
   end
 
   # Struct type
@@ -218,19 +232,21 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
 
         do_get_kotlin_type(unwrapped_type, unwrapped_constraints)
 
-      # Check if it's any Ash type
+      # An Ash type this module has no case for. `@Contextual` rather than a bare
+      # `Any` so the field still compiles inside a `@Serializable` class; the
+      # consumer registers a serializer for it, or configures
+      # :type_mapping_overrides to name a concrete Kotlin type.
       Introspection.is_ash_type?(type) ->
-        # Unknown Ash type, default to Any
-        "Any"
+        "@Contextual Any"
 
       true ->
         # Module that might be a custom type
-        "Any"
+        "@Contextual Any"
     end
   end
 
   # Fallback for non-atom types
-  defp map_type(_, _constraints), do: "Any"
+  defp map_type(_, _constraints), do: "@Contextual Any"
 
   @doc """
   Checks if a module has interop_field_names/0 callback.

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -290,9 +290,13 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
 
   @doc """
   Checks if an Ash type should be generated as a Kotlin enum class.
+
+  Requires `:one_of` to hold a list, not merely to be present.
+  `AshKotlinMultiplatform.Codegen.ResourceSchemas.collect_types/1` generates no
+  class for a nil `:one_of`, so a field must not name one for it either.
   """
   def is_enum_type?(type, constraints) do
-    type == Ash.Type.Atom and Keyword.has_key?(constraints, :one_of)
+    type == Ash.Type.Atom and is_list(Keyword.get(constraints, :one_of))
   end
 
   @doc """

--- a/test/ash_kotlin_multiplatform/codegen/contextual_any_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/contextual_any_test.exs
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Codegen.ContextualAnyTest do
+  @moduledoc """
+  kotlinx-serialization has no serializer for `Any`, so a bare `Any` anywhere
+  inside a `@Serializable` declaration is a compile error, not a runtime one:
+  "Serializer has not been found for type 'Any'". Every schema type this library
+  emits is `@Serializable`, so none of them may carry one.
+  """
+  # Not async: one describe swaps :untyped_map_type, which is global.
+  use ExUnit.Case, async: false
+
+  alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Test.{Author, Book, Event, Todo, User}
+
+  @resources [Author, Book, Event, Todo, User]
+
+  defp schemas do
+    {data_classes, embedded_classes, enum_classes, sealed_classes} =
+      ResourceSchemas.generate_all_schemas(@resources)
+
+    Enum.join([data_classes, embedded_classes, enum_classes, sealed_classes], "\n")
+  end
+
+  defp bare_anys(kotlin) do
+    ~r/(?<!@Contextual )\bAny\b/
+    |> Regex.scan(kotlin, return: :index)
+    |> Enum.map(fn [{start, _}] ->
+      kotlin
+      |> String.slice(max(start - 60, 0), 120)
+      |> String.trim()
+    end)
+  end
+
+  describe "the generated schema types" do
+    test "carry no bare Any" do
+      assert bare_anys(schemas()) == []
+    end
+
+    test "annotate an untyped map attribute" do
+      assert schemas() =~ "val metadata: Map<String, @Contextual Any?>? = null"
+    end
+
+    test "annotate a keyword attribute" do
+      assert schemas() =~ "val settings: Map<String, @Contextual Any?>? = null"
+    end
+
+    test "annotate a tuple attribute" do
+      assert schemas() =~ "val position: List<@Contextual Any?>? = null"
+    end
+
+    test "annotate an attribute whose Ash type has no Kotlin mapping" do
+      assert schemas() =~ "val scratch: @Contextual Any? = null"
+    end
+
+    test "annotate an untyped map inside a union subclass" do
+      assert schemas() =~ "val value: Map<String, @Contextual Any?>"
+    end
+  end
+
+  describe "a configured untyped_map_type without the annotation" do
+    setup do
+      previous = Application.get_env(:ash_kotlin_multiplatform, :untyped_map_type)
+      Application.put_env(:ash_kotlin_multiplatform, :untyped_map_type, "Map<String, Any?>")
+
+      on_exit(fn ->
+        case previous do
+          nil -> Application.delete_env(:ash_kotlin_multiplatform, :untyped_map_type)
+          value -> Application.put_env(:ash_kotlin_multiplatform, :untyped_map_type, value)
+        end
+      end)
+
+      :ok
+    end
+
+    test "is still annotated on the way into a serializable field" do
+      assert bare_anys(schemas()) == []
+    end
+  end
+end

--- a/test/ash_kotlin_multiplatform/codegen/resource_schemas_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/resource_schemas_test.exs
@@ -12,6 +12,10 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemasTest do
     test "a union attribute names the sealed class generated for it" do
       assert ResourceSchemas.generate_data_class(Todo) =~ "val content: ContentUnion? = null"
     end
+
+    test "a one_of atom attribute names the enum class generated for it" do
+      assert ResourceSchemas.generate_data_class(Todo) =~ "val status: Status? = null"
+    end
   end
 
   describe "generate_enum_class/1" do

--- a/test/ash_kotlin_multiplatform/codegen/resource_schemas_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/resource_schemas_test.exs
@@ -6,6 +6,13 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemasTest do
   use ExUnit.Case, async: true
 
   alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Test.Todo
+
+  describe "generate_data_class/1" do
+    test "a union attribute names the sealed class generated for it" do
+      assert ResourceSchemas.generate_data_class(Todo) =~ "val content: ContentUnion? = null"
+    end
+  end
 
   describe "generate_enum_class/1" do
     test "generates enum class with SerialName annotations" do

--- a/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
@@ -63,9 +63,19 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
       assert TypeMapper.get_kotlin_type(attr) == "List<String>?"
     end
 
-    test "maps Map type to Map<String, Any?>" do
+    test "maps Map type to a contextual untyped map" do
       attr = %{type: Ash.Type.Map, constraints: [], allow_nil?: false}
-      assert TypeMapper.get_kotlin_type(attr) == "Map<String, Any?>"
+      assert TypeMapper.get_kotlin_type(attr) == "Map<String, @Contextual Any?>"
+    end
+
+    test "maps Keyword type to a contextual untyped map" do
+      attr = %{type: Ash.Type.Keyword, constraints: [], allow_nil?: false}
+      assert TypeMapper.get_kotlin_type(attr) == "Map<String, @Contextual Any?>"
+    end
+
+    test "maps Tuple type to a list of contextual values" do
+      attr = %{type: Ash.Type.Tuple, constraints: [], allow_nil?: false}
+      assert TypeMapper.get_kotlin_type(attr) == "List<@Contextual Any?>"
     end
 
     test "maps Decimal type to String" do
@@ -87,8 +97,17 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
       assert TypeMapper.get_kotlin_type_for_type({:array, Ash.Type.Integer}) == "List<Int>"
     end
 
-    test "handles unknown types as Any" do
-      assert TypeMapper.get_kotlin_type_for_type(:unknown_type) == "Any"
+    test "handles unknown types as a contextual Any" do
+      assert TypeMapper.get_kotlin_type_for_type(:unknown_type) == "@Contextual Any"
+    end
+
+    test "handles an Ash type with no mapping as a contextual Any" do
+      assert TypeMapper.get_kotlin_type_for_type(Ash.Type.Term) == "@Contextual Any"
+    end
+
+    test "handles a union with no owning attribute as a contextual Any" do
+      constraints = [types: [text: [type: Ash.Type.String]]]
+      assert TypeMapper.get_kotlin_type_for_type(Ash.Type.Union, constraints) == "@Contextual Any"
     end
   end
 
@@ -123,6 +142,29 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
 
       assert TypeMapper.annotate_contextual_types("kotlinx.datetime.LocalDateTime") ==
                "kotlinx.datetime.LocalDateTime"
+    end
+
+    test "annotates a bare Any" do
+      assert TypeMapper.annotate_contextual_types("Any?") == "@Contextual Any?"
+    end
+
+    test "annotates the value type of a configured untyped map" do
+      assert TypeMapper.annotate_contextual_types("Map<String, Any?>") ==
+               "Map<String, @Contextual Any?>"
+    end
+
+    test "annotates the element type of a list of Any" do
+      assert TypeMapper.annotate_contextual_types("List<Any?>?") == "List<@Contextual Any?>?"
+    end
+
+    test "leaves a type whose name merely starts with Any alone" do
+      assert TypeMapper.annotate_contextual_types("AnyOf?") == "AnyOf?"
+      assert TypeMapper.annotate_contextual_types("List<Anything>") == "List<Anything>"
+    end
+
+    test "is idempotent for Any" do
+      once = TypeMapper.annotate_contextual_types("Map<String, Any?>")
+      assert TypeMapper.annotate_contextual_types(once) == once
     end
 
     test "leaves java.time.Instant alone" do

--- a/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
@@ -111,6 +111,26 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
     end
   end
 
+  describe "is_enum_type?/2" do
+    test "is true for an atom constrained to a list of values" do
+      assert TypeMapper.is_enum_type?(Ash.Type.Atom, one_of: [:a, :b])
+    end
+
+    test "is false for an unconstrained atom" do
+      refute TypeMapper.is_enum_type?(Ash.Type.Atom, [])
+    end
+
+    # ResourceSchemas.collect_types/1 skips a nil :one_of, so the field must not
+    # name an enum class for one either — the class would never be generated.
+    test "is false when one_of is present but nil" do
+      refute TypeMapper.is_enum_type?(Ash.Type.Atom, one_of: nil)
+    end
+
+    test "is false for a non-atom type" do
+      refute TypeMapper.is_enum_type?(Ash.Type.String, one_of: [:a, :b])
+    end
+  end
+
   describe "annotate_contextual_types/1" do
     test "annotates a bare Instant in type position" do
       assert TypeMapper.annotate_contextual_types("kotlinx.datetime.Instant") ==

--- a/test/support/resources/todo.ex
+++ b/test/support/resources/todo.ex
@@ -3,13 +3,25 @@
 # SPDX-License-Identifier: MIT
 
 defmodule AshKotlinMultiplatform.Test.Todo do
-  @moduledoc false
+  @moduledoc """
+  Carries the attribute types that have no direct Kotlin equivalent.
+
+  `Ash.Type.Map`, `Ash.Type.Keyword`, `Ash.Type.Tuple`, `Ash.Type.Union` and any
+  Ash type the mapper does not recognise all reach Kotlin as `Any`, which
+  kotlinx-serialization refuses inside a `@Serializable` class ("Serializer has
+  not been found for type 'Any'"). `:status` is public for the matching reason on
+  the other side: an `:atom` with `one_of` has an enum class generated for it, so
+  the field has to name that class rather than `String`.
+
+  Only `Ash.Resource.Info.public_attributes/1` reaches the generator, hence
+  `public? true` on every attribute that is here to be generated.
+  """
   use Ash.Resource,
     domain: AshKotlinMultiplatform.Test.Domain,
     extensions: [AshKotlinMultiplatform.Resource]
 
   kotlin_multiplatform do
-    type_name "Todo"
+    type_name("Todo")
   end
 
   attributes do
@@ -24,11 +36,38 @@ defmodule AshKotlinMultiplatform.Test.Todo do
     attribute :status, :atom do
       constraints one_of: [:pending, :in_progress, :completed]
       default :pending
+      public? true
     end
 
     attribute :priority, :integer do
       default 0
     end
+
+    attribute :metadata, :map, public?: true
+
+    attribute :settings, :keyword do
+      constraints fields: [notify: [type: :boolean]]
+      public? true
+    end
+
+    attribute :position, :tuple do
+      constraints fields: [x: [type: :integer], y: [type: :integer]]
+      public? true
+    end
+
+    attribute :content, :union do
+      constraints types: [
+                    text: [type: :string],
+                    note: [type: :map, constraints: [fields: [body: [type: :string]]]],
+                    blob: [type: :map]
+                  ]
+
+      public? true
+    end
+
+    # Ash.Type.Term is a real Ash type the mapper has no case for, so it takes the
+    # unknown-type fallback rather than any of the branches above.
+    attribute :scratch, Ash.Type.Term, public?: true
 
     attribute :due_date, :date
 


### PR DESCRIPTION
Closes #20.

Generated Kotlin did not compile for any resource with a map, union, tuple,
keyword or unmapped-type attribute, and the enum and sealed classes the
generator emitted were referenced by nothing.

## Verified with a real compiler, not string inspection

Run through the #37 compile gate that landed in #47
(`MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` then
`gradle compileKotlin`, Gradle 9.7.0 / Temurin 21 / Kotlin 2.4.20).

Same fixtures, `main`'s library code — **6 errors**:

```
e: AshRpc.kt:109:31 Serializer was not found for type 'Any?'...
e: AshRpc.kt:110:31 Serializer was not found for type 'Any?'...
e: AshRpc.kt:111:24 Serializer was not found for type 'Any?'...
e: AshRpc.kt:112:18 Serializer was not found for type 'Any?'...
e: AshRpc.kt:113:18 Serializer was not found for type 'Any?'...
e: AshRpc.kt:152:32 Serializer was not found for type 'Any?'...
```

This branch — **0**. The only errors left in the gate are #44 (2) and #45 (13),
both filed and neither touched here.

Runtime probe on the compiled classes, decoding real JSON with
kotlinx-serialization 1.9.0:

```
OK   enum field decodes            {"id":"1","status":"in_progress"} -> Status.IN_PROGRESS
OK   absent untyped map decodes
OK   null untyped map decodes
FAIL populated untyped map decodes -> SerializationException: Serializer for class 'Any' is not found
OK   union field decodes           {"content":{"type":"text","value":"hi"}}
```

## What changed

**`@Contextual` on every generated `Any`.** kotlinx-serialization has no
serializer for `Any`, so a bare `Any` inside a `@Serializable` class is a compile
error. `annotate_contextual_types/1` learned `Any` alongside
`kotlinx.datetime.Instant`; the `untyped_map_type` default, the tuple mapping and
the unknown/custom-type fallback now emit it at the source too. This is the trade
`ConfigBuilder` already makes for its `filter` and `page` maps.

**Union attribute fields name their sealed class.** `collect_types/1` emitted one
sealed class per public union attribute while the field kept `Any`, so the class
was generated and referenced by nothing.

**`one_of` atom attribute fields name their enum class.** Same orphan; the field
kept `String`.

Both names derive from the attribute name, which `TypeMapper` never sees, so the
lookup lives in `ResourceSchemas`. `collect_types_from_attribute/4` and the field
generator now share `is_enum_type?/2` and `is_union_type?/1`, so the set of
classes generated and the set a field may name cannot drift into orphans or
dangling references. The wiring is deliberately confined to resource attributes —
a union or `one_of` atom reached through an action argument or a union member has
no generated class, and naming one there would emit a dangling reference.

`is_enum_type?/2` tightened to require `:one_of` to hold a list, matching what
collection already did with a nil `:one_of`.

## Fixtures

`Todo` gains public `:map`, `:keyword`, `:tuple`, `:union`, `Ash.Type.Term` and
`one_of` `:atom` attributes, and `:status` becomes public. Only
`Ash.Resource.Info.public_attributes/1` reaches the generator, so before this
none of these paths were exercised at all — which is why the gate was green on
`main` despite the defects being real.

## Test plan

- `mix test` — 118 tests, 0 failures (96 before).
- `mix compile --force --warnings-as-errors` — clean.
- `mix hex.audit`, `mix deps.audit` — clean.
- Compile gate: red on `main`+fixtures with the 6 errors above, green here.
- New `contextual_any_test.exs` scans every emitted schema type for a bare `Any`,
  including with `:untyped_map_type` configured *without* the annotation.

## Not fixed here

A **populated** untyped map still throws at runtime unless the consumer registers
a serializer for `Any` on the `SerializersModule` — `@Contextual` fixes
compilation, not decoding. Documented on `untyped_map_type/0`. Mapping untyped
maps to `JsonElement`, or registering an `Any` serializer in
`kotlin_static.ex`, is a separate change; #30 covers the neighbouring case of
giving specific types concrete mappings.

Input types still emit `String` for a `one_of` argument where the data class now
emits the enum. Both serialize to the same JSON, so it compiles and round-trips;
widening the wiring to arguments needs the dangling-reference question answered
first (#33).
