### PR TITLE
fix: the generated Kotlin compiles, and the gate now enforces it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,18 +52,6 @@ jobs:
   # Hands the emitted Kotlin to a real Kotlin compiler. Every "generated code
   # does not compile" defect so far (#20, #23, #24, #30, #33) was found by a
   # human reading strings; this job is the machine that should have found them.
-  #
-  # NOT BLOCKING YET. The gate is red on arrival, on two defects it found the
-  # first time it ran:
-  #
-  #   * #44 - a relationship to a resource the Kotlin DSL never published emits
-  #     `List<Secret>` with no `Secret` type anywhere in the file.
-  #   * #45 - `datetime_library: :java_time` emits java.time types into
-  #     @Serializable classes with no serializer, so every date/time field is a
-  #     SERIALIZER_NOT_FOUND error.
-  #
-  # Close both and drop `continue-on-error` from the compile step below (#46).
-  # A required check that is red on arrival teaches everyone to ignore CI.
   kotlin-compile-gate:
     name: Compile the generated Kotlin
     runs-on: ubuntu-latest
@@ -111,21 +99,5 @@ jobs:
           gradle-version: "9.7.0"
 
       - name: Compile the generated Kotlin
-        id: compile
-        continue-on-error: true
         working-directory: test/fixtures/kotlin_compile
         run: gradle compileKotlin --console=plain
-
-      - name: Report gate result
-        run: |
-          if [ "${{ steps.compile.outcome }}" = "success" ]; then
-            echo "Generated Kotlin compiles." >> "$GITHUB_STEP_SUMMARY"
-          else
-            {
-              echo "## The generated Kotlin does not compile"
-              echo
-              echo "Compiler output is in the \"Compile the generated Kotlin\" step above."
-              echo
-              echo "This step is not blocking yet - see the comment in .github/workflows/ci.yml."
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi

--- a/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
@@ -124,7 +124,11 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypes do
   These are the primitive filter types used by resource filters.
   """
   def generate_base_filter_types do
-    date_type = TypeMapper.get_kotlin_type_for_type(Ash.Type.Date)
+    # Both go through the annotator: `kotlinx.datetime.LocalDate` comes back
+    # untouched because kotlinx-datetime serializes it, while `java.time.LocalDate`
+    # picks up the `@Contextual` its serializer is registered under.
+    date_type =
+      TypeMapper.annotate_contextual_types(TypeMapper.get_kotlin_type_for_type(Ash.Type.Date))
 
     instant_type =
       TypeMapper.annotate_contextual_types(

--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -26,14 +26,18 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
     # Collect all types that need generation
     {enums, unions, embedded} = collect_types(resources)
 
+    # Exactly the resources this pass declares a data class for. Nothing else may
+    # be named by a relationship field - see `generate_relationship_fields/2`.
+    emitted = resources ++ embedded
+
     data_classes =
       resources
-      |> Enum.map(&generate_data_class/1)
+      |> Enum.map(&generate_data_class(&1, emitted))
       |> Enum.join("\n\n")
 
     embedded_classes =
       embedded
-      |> Enum.map(&generate_embedded_class/1)
+      |> Enum.map(&generate_embedded_class(&1, emitted))
       |> Enum.join("\n\n")
 
     enum_classes =
@@ -114,19 +118,21 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
 
   @doc """
   Generates a Kotlin data class for an Ash resource including relationships.
+
+  `emitted_resources` is every resource the same generation pass declares a class
+  for. A relationship whose destination is not in it is dropped rather than
+  emitted against a type that does not exist; pass the full set, not just the
+  resource being generated.
   """
-  def generate_data_class(resource) do
+  def generate_data_class(resource, emitted_resources) do
     type_name = get_kotlin_type_name(resource)
     attributes = Ash.Resource.Info.public_attributes(resource)
-    relationships = get_public_relationships(resource)
 
     attribute_fields =
       attributes
       |> Enum.map(&generate_field/1)
 
-    relationship_fields =
-      relationships
-      |> Enum.map(fn rel -> generate_relationship_field(resource, rel) end)
+    relationship_fields = generate_relationship_fields(resource, emitted_resources)
 
     all_fields =
       (attribute_fields ++ relationship_fields)
@@ -140,6 +146,24 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
     """
   end
 
+  # A relationship field may only name a class this file declares. `Author` has a
+  # public `has_many :secrets` to a resource the Kotlin DSL never published, and
+  # emitting `List<Secret>` for it made every generated file fail to compile with
+  # "Unresolved reference 'Secret'" (#44).
+  #
+  # Dropping the field is what the server already does. `AshKotlinMultiplatform.Rpc.Runner`
+  # hands `FieldSelector` an `is_interop_resource?` gate, so a nested request into
+  # `Author.secrets` comes back `unknown_field`. Generating the missing class instead
+  # would publish a resource the DSL deliberately withheld.
+  defp generate_relationship_fields(resource, emitted_resources) do
+    emitted = MapSet.new(emitted_resources)
+
+    resource
+    |> get_public_relationships()
+    |> Enum.filter(&MapSet.member?(emitted, &1.destination))
+    |> Enum.map(&generate_relationship_field/1)
+  end
+
   defp get_public_relationships(resource) do
     try do
       Ash.Resource.Info.public_relationships(resource)
@@ -151,8 +175,8 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
   @doc """
   Generates a Kotlin data class for an embedded Ash resource.
   """
-  def generate_embedded_class(resource) do
-    generate_data_class(resource)
+  def generate_embedded_class(resource, emitted_resources) do
+    generate_data_class(resource, emitted_resources)
   end
 
   defp generate_field(attribute) do
@@ -226,7 +250,7 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
 
   defp get_default_for_type(_kotlin_type), do: "null"
 
-  defp generate_relationship_field(_resource, rel) do
+  defp generate_relationship_field(rel) do
     field_name = format_field_name(rel.name)
     original_name = Atom.to_string(rel.name)
     related_type_name = get_kotlin_type_name(rel.destination)

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -20,6 +20,30 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   # Kotlin types with no serializer the compiler can resolve on its own.
   @contextual_types ["kotlinx.datetime.Instant", "Any"]
 
+  # Every java.time type `map_type/2` can emit. kotlinx-serialization ships a
+  # serializer for none of them, so all of them need the annotation and the
+  # matching entry in the `SerializersModule`
+  # `AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic.generate_http_client_factory/0`
+  # builds. Longer names are not shadowed by shorter prefixes: the trailing `\b`
+  # in the pattern below rejects `java.time.LocalDate` inside
+  # `java.time.LocalDateTime`.
+  @java_time_contextual_types [
+    "java.time.LocalDate",
+    "java.time.LocalTime",
+    "java.time.Instant",
+    "java.time.ZonedDateTime",
+    "java.time.LocalDateTime"
+  ]
+
+  @doc """
+  Returns every java.time type the mapper can emit.
+
+  `AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic` declares one `KSerializer` per
+  entry, so the list is the single source of truth for which types get annotated
+  and which get a serializer. The two must not drift.
+  """
+  def java_time_contextual_types, do: @java_time_contextual_types
+
   @doc """
   Returns the Kotlin type for an Ash attribute.
 
@@ -61,7 +85,7 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   @doc """
   Annotates the types that have no compile-time serializer with `@Contextual`.
 
-  Two types need it.
+  Three groups need it.
 
   `kotlinx.datetime.Instant`: kotlinx-datetime 0.6 shipped a default serializer for
   it; 0.7 deprecated the class in favour of `kotlin.time.Instant` and dropped both
@@ -83,15 +107,26 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   `@Contextual val x: List<Instant>` would look for a serializer registered for
   `List<Instant>` and fail at runtime.
 
-  `java.time.Instant` is left alone — `:java_time` consumers supply their own
-  serializers. Matches whole words only, so `Any` does not touch `AnyOf` or a
-  resource named `Anything`. Idempotent, so it is safe to apply to an
-  already-annotated type.
+  The `java.time` types, under `datetime_library: :java_time` only:
+  kotlinx-serialization has a serializer for none of them, so every date or time
+  field was a SERIALIZER_NOT_FOUND compile error and the option could not produce a
+  compiling client at all (#45). `KotlinStatic` registers an ISO-8601 serializer per
+  type, which is what this annotation resolves against.
+
+  Matches whole words only, so `Any` does not touch `AnyOf` or a resource named
+  `Anything`. Idempotent, so it is safe to apply to an already-annotated type.
   """
   def annotate_contextual_types(kotlin_type) when is_binary(kotlin_type) do
-    Enum.reduce(@contextual_types, kotlin_type, fn type, acc ->
+    Enum.reduce(contextual_types(), kotlin_type, fn type, acc ->
       String.replace(acc, ~r/(?<!@Contextual )\b#{Regex.escape(type)}\b/, "@Contextual #{type}")
     end)
+  end
+
+  defp contextual_types do
+    case AshKotlinMultiplatform.datetime_library() do
+      :java_time -> @contextual_types ++ @java_time_contextual_types
+      _kotlinx_datetime -> @contextual_types
+    end
   end
 
   defp do_get_kotlin_type(type, constraints) do

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -13,25 +13,27 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   Generates the standard imports for the generated Kotlin file.
   """
   def generate_imports(_opts \\ []) do
-    datetime_imports =
+    # Both settings hand-write KSerializers, so both need the serialization
+    # plumbing that declares and registers them.
+    datetime_package =
       case AshKotlinMultiplatform.datetime_library() do
-        :kotlinx_datetime ->
-          """
-          import kotlinx.datetime.*
-          import kotlinx.serialization.KSerializer
-          import kotlinx.serialization.descriptors.PrimitiveKind
-          import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-          import kotlinx.serialization.descriptors.SerialDescriptor
-          import kotlinx.serialization.encoding.Decoder
-          import kotlinx.serialization.encoding.Encoder
-          import kotlinx.serialization.modules.SerializersModule
-          import kotlinx.serialization.modules.contextual
-          """
-          |> String.trim_trailing()
-
-        :java_time ->
-          "import java.time.*"
+        :kotlinx_datetime -> "import kotlinx.datetime.*"
+        :java_time -> "import java.time.*"
       end
+
+    datetime_imports =
+      """
+      #{datetime_package}
+      import kotlinx.serialization.KSerializer
+      import kotlinx.serialization.descriptors.PrimitiveKind
+      import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+      import kotlinx.serialization.descriptors.SerialDescriptor
+      import kotlinx.serialization.encoding.Decoder
+      import kotlinx.serialization.encoding.Encoder
+      import kotlinx.serialization.modules.SerializersModule
+      import kotlinx.serialization.modules.contextual
+      """
+      |> String.trim_trailing()
 
     websocket_imports =
       if AshKotlinMultiplatform.generate_phoenix_channel_client?() do
@@ -63,43 +65,14 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   Generates a helper function to create a configured HttpClient.
   """
   def generate_http_client_factory do
-    # kotlinx-datetime 0.7 removed the concrete InstantIso8601Serializer object (Instant is
-    # deprecated in favor of kotlin.time.Instant there) in favor of an abstract
-    # FormattedInstantSerializer base that doesn't exist before 0.7. Neither name is safe to
-    # reference unconditionally — this codegen has no way to know which kotlinx-datetime
-    # version a given consumer has pinned — so this hand-writes a KSerializer against only
-    # Instant.toString()/Instant.parse(), which are stable ISO-8601 API across that version
-    # split. Fields typed as Instant are emitted as @Contextual (see
-    # ResourceSchemas.generate_field/1) and resolved through the SerializersModule below at
-    # runtime.
-    {instant_serializer_decl, serializers_module} =
+    {serializer_decls, serializers_module} =
       case AshKotlinMultiplatform.datetime_library() do
-        :kotlinx_datetime ->
-          decl = """
-          private object InstantIso8601Serializer : KSerializer<kotlinx.datetime.Instant> {
-              override val descriptor: SerialDescriptor =
-                  PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
-
-              override fun serialize(encoder: Encoder, value: kotlinx.datetime.Instant) {
-                  encoder.encodeString(value.toString())
-              }
-
-              override fun deserialize(decoder: Decoder): kotlinx.datetime.Instant {
-                  return kotlinx.datetime.Instant.parse(decoder.decodeString())
-              }
-          }
-
-          """
-
-          {decl,
-           "\n                    serializersModule = SerializersModule { contextual(InstantIso8601Serializer) }"}
-
-        :java_time ->
-          {"", ""}
+        :kotlinx_datetime -> kotlinx_datetime_serializers()
+        :java_time -> java_time_serializers()
       end
 
     """
-    #{instant_serializer_decl}// HTTP Client factory
+    #{serializer_decls}// HTTP Client factory
     fun createHttpClient(): HttpClient {
         return HttpClient {
             install(ContentNegotiation) {
@@ -112,6 +85,94 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
     }
     """
   end
+
+  # kotlinx-datetime 0.7 removed the concrete InstantIso8601Serializer object (Instant is
+  # deprecated in favor of kotlin.time.Instant there) in favor of an abstract
+  # FormattedInstantSerializer base that doesn't exist before 0.7. Neither name is safe to
+  # reference unconditionally — this codegen has no way to know which kotlinx-datetime
+  # version a given consumer has pinned — so this hand-writes a KSerializer against only
+  # Instant.toString()/Instant.parse(), which are stable ISO-8601 API across that version
+  # split. Fields typed as Instant are emitted as @Contextual (see
+  # ResourceSchemas.generate_field/1) and resolved through the SerializersModule at runtime.
+  #
+  # The other kotlinx-datetime types keep their built-in serializers, so they need
+  # neither a declaration here nor the annotation.
+  defp kotlinx_datetime_serializers do
+    decl = """
+    private object InstantIso8601Serializer : KSerializer<kotlinx.datetime.Instant> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("kotlinx.datetime.Instant", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: kotlinx.datetime.Instant) {
+            encoder.encodeString(value.toString())
+        }
+
+        override fun deserialize(decoder: Decoder): kotlinx.datetime.Instant {
+            return kotlinx.datetime.Instant.parse(decoder.decodeString())
+        }
+    }
+
+    """
+
+    {decl,
+     "\n                serializersModule = SerializersModule { contextual(InstantIso8601Serializer) }"}
+  end
+
+  # kotlinx-serialization ships a serializer for no java.time type, so every date or
+  # time field under `datetime_library: :java_time` was a SERIALIZER_NOT_FOUND compile
+  # error (#45). Annotating the fields `@Contextual` alone would only move the failure
+  # to decode time, so each type also gets a serializer registered here.
+  #
+  # ISO-8601 both ways, which is what an Ash JSON API sends and accepts. Every type
+  # below round-trips through `toString()`/`parse()` on that format — except
+  # ZonedDateTime, whose `toString()` appends the region in brackets
+  # ("2026-01-01T00:00Z[Europe/Paris]"), which Ash's datetime parser rejects. It is
+  # written with ISO_OFFSET_DATE_TIME instead; `ZonedDateTime.parse` reads both forms.
+  defp java_time_serializers do
+    types = AshKotlinMultiplatform.Codegen.TypeMapper.java_time_contextual_types()
+
+    decls =
+      types
+      |> Enum.map_join("\n", &java_time_serializer_declaration/1)
+      |> Kernel.<>("\n")
+
+    registrations =
+      Enum.map_join(types, "\n", fn type ->
+        "                    contextual(#{java_time_serializer_name(type)})"
+      end)
+
+    module =
+      "\n                serializersModule = SerializersModule {\n" <>
+        registrations <> "\n                }"
+
+    {decls, module}
+  end
+
+  defp java_time_serializer_declaration(type) do
+    """
+    private object #{java_time_serializer_name(type)} : KSerializer<#{type}> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("#{type}", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: #{type}) {
+            encoder.encodeString(#{java_time_encoded_value(type)})
+        }
+
+        override fun deserialize(decoder: Decoder): #{type} {
+            return #{type}.parse(decoder.decodeString())
+        }
+    }
+    """
+  end
+
+  defp java_time_serializer_name(type) do
+    "Java" <> String.replace_prefix(type, "java.time.", "") <> "Iso8601Serializer"
+  end
+
+  defp java_time_encoded_value("java.time.ZonedDateTime"),
+    do: "java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(value)"
+
+  defp java_time_encoded_value(_type), do: "value.toString()"
 
   @doc """
   Generates type aliases for common types.

--- a/test/ash_kotlin_multiplatform/codegen/filter_types_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/filter_types_test.exs
@@ -54,20 +54,21 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypesTest do
       :ok
     end
 
-    test "DateFilter names java.time.LocalDate" do
+    # kotlinx-serialization has no serializer for any java.time type, so unlike the
+    # kotlinx-datetime block above, DateFilter needs the annotation too (#45).
+    test "DateFilter names java.time.LocalDate, annotated @Contextual" do
       kotlin = FilterTypes.generate_base_filter_types()
 
-      assert kotlin =~ "val eq: java.time.LocalDate? = null"
-      assert kotlin =~ "val inValues: List<java.time.LocalDate>? = null"
+      assert kotlin =~ "val eq: @Contextual java.time.LocalDate? = null"
+      assert kotlin =~ "val inValues: List<@Contextual java.time.LocalDate>? = null"
       refute kotlin =~ "kotlinx.datetime"
     end
 
-    test "InstantFilter names java.time.Instant, left bare (no @Contextual)" do
+    test "InstantFilter names java.time.Instant, annotated @Contextual" do
       kotlin = FilterTypes.generate_base_filter_types()
 
-      assert kotlin =~ "val eq: java.time.Instant? = null"
-      assert kotlin =~ "val inValues: List<java.time.Instant>? = null"
-      refute kotlin =~ "@Contextual"
+      assert kotlin =~ "val eq: @Contextual java.time.Instant? = null"
+      assert kotlin =~ "val inValues: List<@Contextual java.time.Instant>? = null"
     end
   end
 end

--- a/test/ash_kotlin_multiplatform/codegen/instant_serialization_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/instant_serialization_test.exs
@@ -50,20 +50,20 @@ defmodule AshKotlinMultiplatform.Codegen.InstantSerializationTest do
 
   describe "resource data classes" do
     test "annotates Instant attributes" do
-      kotlin = ResourceSchemas.generate_data_class(Event)
+      kotlin = ResourceSchemas.generate_data_class(Event, [Event])
 
       assert kotlin =~ "val occurredAt: @Contextual kotlinx.datetime.Instant? = null"
       assert_no_bare_instants(kotlin)
     end
 
     test "annotates the element type of an Instant list, not the list itself" do
-      kotlin = ResourceSchemas.generate_data_class(Event)
+      kotlin = ResourceSchemas.generate_data_class(Event, [Event])
 
       assert kotlin =~ "val reminderAts: List<@Contextual kotlinx.datetime.Instant>? = null"
     end
 
     test "leaves types with a built-in serializer bare" do
-      kotlin = ResourceSchemas.generate_data_class(Event)
+      kotlin = ResourceSchemas.generate_data_class(Event, [Event])
 
       assert kotlin =~ "val startsOn: kotlinx.datetime.LocalDate? = null"
     end

--- a/test/ash_kotlin_multiplatform/codegen/java_time_serialization_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/java_time_serialization_test.exs
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Codegen.JavaTimeSerializationTest do
+  @moduledoc """
+  `datetime_library: :java_time` has to produce a client that compiles and decodes.
+
+  kotlinx-serialization ships no serializer for any `java.time` type, so a bare
+  `java.time.LocalDate` field inside a `@Serializable` class is a compile error -
+  SERIALIZER_NOT_FOUND - not a runtime one. The option is documented in
+  `README.md`, and until #45 it could not produce a compiling client for any
+  resource with a date attribute.
+
+  The fix mirrors what `:kotlinx_datetime` already does for `Instant`: annotate the
+  fields `@Contextual` and register a hand-written ISO-8601 `KSerializer` for each
+  type in the `SerializersModule` of `createHttpClient()`. Annotation alone would
+  trade a compile error for a decode-time throw.
+  """
+  # Not async: swaps :datetime_library, which is global.
+  use ExUnit.Case, async: false
+
+  alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Rpc.Codegen
+  alias AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic
+  alias AshKotlinMultiplatform.Test.Event
+
+  @java_time_types [
+    "java.time.LocalDate",
+    "java.time.LocalTime",
+    "java.time.Instant",
+    "java.time.ZonedDateTime",
+    "java.time.LocalDateTime"
+  ]
+
+  # The serializer declarations name their own types outside any field, so exempt
+  # the lines that carry them.
+  @serializer_lines [
+    "Iso8601Serializer",
+    "PrimitiveSerialDescriptor(",
+    "fun serialize(",
+    "fun deserialize(",
+    ".parse(",
+    "DateTimeFormatter"
+  ]
+
+  defp bare_java_times(kotlin) do
+    kotlin
+    |> String.split("\n")
+    |> Enum.reject(fn line -> Enum.any?(@serializer_lines, &String.contains?(line, &1)) end)
+    |> Enum.filter(fn line ->
+      Enum.any?(@java_time_types, fn type ->
+        String.contains?(line, type) and not String.contains?(line, "@Contextual #{type}")
+      end)
+    end)
+  end
+
+  defp assert_no_bare_java_times(kotlin) do
+    assert bare_java_times(kotlin) == [],
+           "java.time type without @Contextual:\n" <> Enum.join(bare_java_times(kotlin), "\n")
+  end
+
+  defp put_datetime_library(library) do
+    previous = Application.get_env(:ash_kotlin_multiplatform, :datetime_library)
+    Application.put_env(:ash_kotlin_multiplatform, :datetime_library, library)
+
+    on_exit(fn ->
+      case previous do
+        nil -> Application.delete_env(:ash_kotlin_multiplatform, :datetime_library)
+        value -> Application.put_env(:ash_kotlin_multiplatform, :datetime_library, value)
+      end
+    end)
+  end
+
+  describe "with datetime_library: :java_time" do
+    setup do
+      put_datetime_library(:java_time)
+
+      previous_domains = Application.get_env(:ash_kotlin_multiplatform, :ash_domains)
+
+      Application.put_env(:ash_kotlin_multiplatform, :ash_domains, [
+        AshKotlinMultiplatform.Test.Domain
+      ])
+
+      on_exit(fn ->
+        case previous_domains do
+          nil -> Application.delete_env(:ash_kotlin_multiplatform, :ash_domains)
+          value -> Application.put_env(:ash_kotlin_multiplatform, :ash_domains, value)
+        end
+      end)
+
+      :ok
+    end
+
+    test "annotates a date attribute" do
+      kotlin = ResourceSchemas.generate_data_class(Event, [Event])
+
+      assert kotlin =~ "val startsOn: @Contextual java.time.LocalDate? = null"
+    end
+
+    test "annotates the element type of a datetime list, not the list itself" do
+      kotlin = ResourceSchemas.generate_data_class(Event, [Event])
+
+      assert kotlin =~ "val reminderAts: List<@Contextual java.time.Instant>? = null"
+    end
+
+    test "declares a serializer for every java.time type it can emit" do
+      kotlin = KotlinStatic.generate_http_client_factory()
+
+      for type <- @java_time_types do
+        assert kotlin =~ "KSerializer<#{type}>",
+               "no KSerializer declared for #{type}"
+      end
+    end
+
+    test "registers every serializer on the Json config" do
+      kotlin = KotlinStatic.generate_http_client_factory()
+
+      assert kotlin =~ "serializersModule = SerializersModule {"
+      assert kotlin =~ "contextual(JavaLocalDateIso8601Serializer)"
+      assert kotlin =~ "contextual(JavaLocalTimeIso8601Serializer)"
+      assert kotlin =~ "contextual(JavaInstantIso8601Serializer)"
+      assert kotlin =~ "contextual(JavaZonedDateTimeIso8601Serializer)"
+      assert kotlin =~ "contextual(JavaLocalDateTimeIso8601Serializer)"
+    end
+
+    test "imports the serialization types the serializers name" do
+      kotlin = KotlinStatic.generate_imports()
+
+      assert kotlin =~ "import java.time.*"
+      assert kotlin =~ "import kotlinx.serialization.KSerializer"
+      assert kotlin =~ "import kotlinx.serialization.modules.SerializersModule"
+      assert kotlin =~ "import kotlinx.serialization.modules.contextual"
+    end
+
+    test "carries no bare java.time type anywhere in the generated file" do
+      {:ok, kotlin} = Codegen.generate_kotlin_code(:ash_kotlin_multiplatform, with_filters: true)
+
+      assert_no_bare_java_times(kotlin)
+    end
+  end
+
+  describe "with datetime_library: :kotlinx_datetime" do
+    setup do
+      put_datetime_library(:kotlinx_datetime)
+      :ok
+    end
+
+    test "emits no java.time serializer" do
+      kotlin = KotlinStatic.generate_http_client_factory()
+
+      refute kotlin =~ "java.time"
+    end
+
+    test "leaves a date attribute bare, since kotlinx-datetime serializes it" do
+      kotlin = ResourceSchemas.generate_data_class(Event, [Event])
+
+      assert kotlin =~ "val startsOn: kotlinx.datetime.LocalDate? = null"
+    end
+  end
+end

--- a/test/ash_kotlin_multiplatform/codegen/resource_schemas_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/resource_schemas_test.exs
@@ -8,13 +8,14 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemasTest do
   alias AshKotlinMultiplatform.Codegen.ResourceSchemas
   alias AshKotlinMultiplatform.Test.Todo
 
-  describe "generate_data_class/1" do
+  describe "generate_data_class/2" do
     test "a union attribute names the sealed class generated for it" do
-      assert ResourceSchemas.generate_data_class(Todo) =~ "val content: ContentUnion? = null"
+      assert ResourceSchemas.generate_data_class(Todo, [Todo]) =~
+               "val content: ContentUnion? = null"
     end
 
     test "a one_of atom attribute names the enum class generated for it" do
-      assert ResourceSchemas.generate_data_class(Todo) =~ "val status: Status? = null"
+      assert ResourceSchemas.generate_data_class(Todo, [Todo]) =~ "val status: Status? = null"
     end
   end
 

--- a/test/ash_kotlin_multiplatform/codegen/unpublished_relationship_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/unpublished_relationship_test.exs
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Codegen.UnpublishedRelationshipTest do
+  @moduledoc """
+  A relationship field may only name a type the same file declares.
+
+  `Author.secrets` is a public `has_many` to `AshKotlinMultiplatform.Test.Secret`,
+  a resource the Kotlin DSL never publishes. The generator used to emit
+  `val secrets: List<Secret>?` against a `Secret` class that exists nowhere, so
+  every generated file failed to compile with "Unresolved reference 'Secret'".
+
+  The client side now agrees with the server side: `AshKotlinMultiplatform.Rpc.Runner`
+  hands `FieldSelector` an `is_interop_resource?` gate so a nested request into
+  `Author.secrets` returns `unknown_field`. A field the server refuses to answer
+  is a field the client has no use for.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Test.{Author, Book}
+
+  defp author_class(emitted) do
+    ResourceSchemas.generate_data_class(Author, emitted)
+  end
+
+  describe "a relationship to a resource with no generated type" do
+    test "is omitted from the data class" do
+      kotlin = author_class([Author, Book])
+
+      refute kotlin =~ "secrets"
+      refute kotlin =~ "Secret"
+    end
+
+    test "is omitted even when the destination is the only thing missing" do
+      kotlin = author_class([Author])
+
+      refute kotlin =~ "Secret"
+      refute kotlin =~ "List<Book>"
+    end
+  end
+
+  describe "a relationship to a published resource" do
+    test "is kept" do
+      assert author_class([Author, Book]) =~ "val books: List<Book>? = null"
+    end
+
+    test "is kept in the belongs_to direction" do
+      assert ResourceSchemas.generate_data_class(Book, [Author, Book]) =~
+               "val author: Author? = null"
+    end
+  end
+
+  describe "the whole schema pass" do
+    test "names no type it does not declare" do
+      {data_classes, embedded_classes, enum_classes, sealed_classes} =
+        ResourceSchemas.generate_all_schemas([Author, Book])
+
+      kotlin = Enum.join([data_classes, embedded_classes, enum_classes, sealed_classes], "\n")
+
+      refute kotlin =~ "Secret"
+      assert kotlin =~ "data class Author("
+      assert kotlin =~ "data class Book("
+    end
+  end
+end


### PR DESCRIPTION
The `gradle compileKotlin` gate added in #47 shipped with `continue-on-error:
true` because the generated Kotlin did not compile. This PR fixes the two
defects it found, so the gate can stop lying about its own result.

Closes #44
Closes #45
Closes #46

## Error count, measured

Run locally with the same command CI runs (Temurin 21, Gradle 9.7.0,
`gradle compileKotlin` in `test/fixtures/kotlin_compile`).

| Subproject | Before | After |
| --- | --- | --- |
| `kotlinx-datetime` | 2 (#44) | 0 |
| `java-time` | 14 — 2 (#44) + 12 (#45) | 0 |
| **Total** | **16** | **0** |

The remaining output is two pre-existing warnings, one per subproject:
"Redundant creation of Json format", from `RpcResult.dataAs()`. Neither is
touched by this PR.

Issue #45 quotes 13 errors; the run on `main` at `18a240e` produces 12. The
`#44` errors appear in both subprojects, which is where the fourth one comes
from.

## #44 — the design call: omit the field

`Author` has a public `has_many :secrets` to `AshKotlinMultiplatform.Test.Secret`,
a resource the Kotlin DSL never publishes. The generator emitted
`val secrets: List<Secret>?` against a class that exists nowhere in the file.

**The generator now drops the field, because that is what the server already
does.** `AshKotlinMultiplatform.Rpc.Runner.field_selector_config/0` hands
`FieldSelector` an `is_interop_resource?` gate
(`Resource.Info.kotlin_multiplatform_resource?/1`), so a nested request into
`Author.secrets` comes back `unknown_field`. A field the server refuses to
answer is a field the client has no use for; emitting it only promised
something no round trip can deliver.

The two alternatives were worse:

- **Generate the missing type.** It contradicts the DSL. The resource was
  deliberately not published, and generating a `Secret` class would hand the
  client a shape for data the server will not return.
- **Fail with a Spark verifier error.** It turns a public Ash relationship into
  a build break for anyone who adds one, and there is nothing wrong with the
  resource — `Secret` is a legitimate server-side resource that simply is not
  part of the client contract. A verifier would force `private?` or publication
  on relationships that want neither.

Implementation: `ResourceSchemas.generate_data_class/2` now takes the set of
resources the same generation pass declares a class for, and a relationship
whose destination is not in that set is filtered out. The set is exact, so a
field and its class cannot drift apart. Arity 1 is gone; callers pass the set.

## #45 — annotate *and* register

`datetime_library: :java_time` put bare `java.time.*` fields inside
`@Serializable` classes. kotlinx-serialization has a serializer for none of
them, so every date/time field was a SERIALIZER_NOT_FOUND compile error. The
option is documented in `README.md`, so it was advertised and could not produce
a compiling client for any resource with a date attribute.

The fix follows the `:kotlinx_datetime` path rather than adding a second
mechanism, per #50:

1. `TypeMapper.annotate_contextual_types/1` now also covers the five java.time
   types `map_type/2` can emit, under `:java_time` only.
2. `KotlinStatic` declares an ISO-8601 `KSerializer` per type and registers all
   five in the `SerializersModule` of `createHttpClient()`.
3. `FilterTypes.generate_base_filter_types/0` runs its date type through the
   annotator too. Under `:kotlinx_datetime` that is a no-op, because
   kotlinx-datetime serializes `LocalDate` itself.

**Annotation alone was not enough**, which is why step 2 is here: `@Contextual`
against an unregistered type compiles and then throws at decode time. That is
the shape of open defect #51, and shipping it deliberately would have been
worse than the compile error.

`ZonedDateTime` is written with `ISO_OFFSET_DATE_TIME`, not `toString()`, which
appends the region in brackets (`2026-01-01T00:00Z[Europe/Paris]`) — a form
Ash's datetime parser rejects. `ZonedDateTime.parse` reads both.

The `java.time` type list lives in
`TypeMapper.java_time_contextual_types/0` and drives both the annotation and
the serializer declarations, so the two cannot go out of sync.

## #46 — the gate is now blocking

`continue-on-error: true` is gone from the "Compile the generated Kotlin" step,
along with the "Report gate result" step and the NOT BLOCKING YET comment. A
generated file that does not compile now fails CI.

## Test plan

- `mix test` — 131 tests, 0 failures (118 on `main`, plus 13 new).
- `MIX_ENV=test mix compile --force --warnings-as-errors` — clean.
- `MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` then
  `gradle compileKotlin` from a wiped fixture — BUILD SUCCESSFUL, 0 errors.

New tests:

- `test/ash_kotlin_multiplatform/codegen/unpublished_relationship_test.exs` — a
  relationship to a resource with no generated type is omitted; one to a
  published resource is kept in both directions; the whole schema pass names no
  type it does not declare.
- `test/ash_kotlin_multiplatform/codegen/java_time_serialization_test.exs` —
  fields annotated, a `KSerializer` declared and registered per type, the
  imports the serializers need, no bare `java.time` anywhere in a fully
  generated file, and the `:kotlinx_datetime` path unchanged.

Updated: `filter_types_test.exs` asserted the old bare `java.time` output as
intended behaviour, which is exactly the defect #45 describes. It now asserts
the annotated form.

## Verified beyond the gate

`generate_filter_types` defaults to `false`, so the fixture does not exercise
filter types. Compiled locally with `with_filters: true` in both subprojects
anyway: BUILD SUCCESSFUL, same two warnings.

## Not in this PR

- With `generate_filter_types: true`, `FilterTypes.generate_all_filter_types/1`
  emits a `SecretFilterInput` and an `AuthorFilterInput.secrets` field for the
  unpublished resource. It compiles — both the reference and the declaration
  exist — so it is not a gate defect, but it is the same "published graph"
  question #44 answers, one layer over. Worth its own issue.
- The Phoenix channel client's `private val json = Json { ... }` instances and
  `RpcResult.dataAs()` build their own `Json` without the `SerializersModule`,
  so a `@Contextual` field decoded through those paths throws. This predates
  the PR and affects the `:kotlinx_datetime` `Instant` path identically; the
  ktor client returned by `createHttpClient()` carries the module and is the
  path the generated RPC functions use.
