### PR TITLE
Binary payloads over the generated Phoenix channel client (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Binary payloads on the generated Phoenix channel client.
+  `PhoenixChannel.pushBinary/3` and `AshRpcChannel.pushBinary/3` send a
+  `ByteArray` as a Phoenix binary frame, which the server receives as
+  `{:binary, data}` in `handle_in/3`; `onBinary/2` and `offBinary/1` bind
+  incoming binary events, and `Push.awaitBinary/0`, `receiveBinary/2` and
+  `awaitPayload/0` read a binary reply. Incoming binary frames were
+  previously dropped by the socket's receive loop. The JSON path is
+  unchanged: `push`, `on`, `receive` and `await` keep their signatures.
+
+### Changed
+
+- **Breaking on the wire.** The generated channel client now speaks
+  Phoenix's v2 protocol. It appends `vsn=2.0.0` on connect and frames text
+  messages as the JSON array `[join_ref, ref, topic, event, payload]`.
+  Previously it sent no `vsn`, so Phoenix negotiated v1 and the client was
+  an unmarked v1 client; v1 has no binary frame at all. The stock Phoenix
+  socket offers both versions and needs no change. A host that narrowed its
+  socket's `serializer:` option to v1 only must add v2.
+- **Breaking on the Kotlin API.** `PhoenixMessage` is no longer
+  `@Serializable` — kotlinx.serialization can only emit the v1 object — and
+  its `joinRef` field no longer carries `@SerialName("join_ref")`. Encode
+  and decode it through the generated `PhoenixSerializer`. `Push.payload` is
+  now a `ChannelPayload` rather than a `JsonElement`, so that a binary push
+  stops reporting a JSON payload it never had; `Push`'s `JsonElement`
+  constructor is kept, so no existing call site changes.
+
 ### Removed
 
 - `AshKotlinMultiplatform.Codegen.ValidationSchemas`, the `with_validation`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# CLAUDE.md
+
+What is true of THIS repository and would otherwise be rediscovered the hard
+way. The global rules apply on top of this file and are not repeated here.
+Created 2026-09-09 on first contact, as issue #49 asked.
+
+## Project source of truth
+
+`docs/` is this project's source of truth: [`docs/PROJECT.md`](docs/PROJECT.md)
+is the hub, with [`architecture.md`](docs/architecture.md),
+[`decisions.md`](docs/decisions.md), [`risks.md`](docs/risks.md) and
+[`roadmap.md`](docs/roadmap.md) under it. If any of them is missing, create
+it before doing anything else, drawing the diagrams from the code that
+exists rather than from the README's claims.
+
+Every PR that changes behaviour, structure, a risk or a decision updates
+them **in the same PR**: move the roadmap item, redraw any diagram the
+change touched, add or retire the risks it created or removed, record the
+decision it made. A merge is not finished until those pages describe `main`
+as it now is. A source of truth that lags is worse than none, because
+readers trust it.
+
+## The product is Kotlin source, so compile it
+
+Assertions like `assert result =~ "class Push("` pass on Kotlin that does
+not compile. Five defects proved it (#20, #23, #24, #30, #33). Any change to
+a generator must go through the compile gate:
+
+```sh
+MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture
+cd test/fixtures/kotlin_compile && gradle compileKotlin --console=plain
+```
+
+`MIX_ENV=test` is load-bearing — it is what puts the test domain into
+`:ash_domains` (`config/config.exs`), so it is what gives the generator any
+resources to emit at all. The gate needs JDK 21 and Gradle 9.7; there is no
+committed wrapper.
+
+## Project-specific lessons
+
+### The compile gate is blocking and green — keep it that way
+
+Since #52 the `kotlin-compile-gate` job has no `continue-on-error`, and
+`gradle compileKotlin` exits 0 on `main`. Two warnings are expected, one per
+subproject: "Redundant creation of Json format", from `RpcResult.dataAs()`.
+Any error is yours. Run the gate before pushing a generator change; the CI
+job will not merge without it.
+
+### `mix format --check-formatted` fails on `main`
+
+Ten files predate the current formatter rules (#38), so a red check does not
+mean you broke something. Run `mix format` on the files you touched and check
+the failing list is unchanged, not empty.
+
+### The channel client is hand-written Phoenix protocol, not kotlinx
+
+`Rpc.Codegen.PhoenixChannel` emits its own serializer for Phoenix's wire
+format. That format lives in the `phoenix` package, not here, so nothing in
+this repository's test suite notices when Phoenix changes it. Read
+`deps/phoenix/lib/phoenix/socket/serializers/v2_json_serializer.ex` and
+`deps/phoenix/assets/js/phoenix/serializer.js` before touching it — never
+work from memory of the format.
+
+Two traps that produce frames the server drops in silence, with no error on
+either side:
+
+* The **`vsn` query parameter selects the serializer**, and an absent `vsn`
+  means v1, not v2 (`deps/phoenix/lib/phoenix/socket.ex:499`). v1 has no
+  binary branch and uses a JSON *object* for text frames; v2 uses a JSON
+  *array*. Changing one without the other breaks every frame.
+* The **binary push layout is not symmetric**. A client-to-server push has
+  five header bytes and carries a ref; a server-to-client push has four and
+  carries none. Reusing one layout for both misreads every incoming frame.
+  The table in [`docs/architecture.md`](docs/architecture.md) has all four
+  layouts.
+
+### `Rpc.Codegen.PhoenixChannel` is static
+
+It takes no resource and no action, so the same Kotlin is emitted for every
+application (#35). Do not reach for the `{resource, action, rpc_action}`
+tuples inside it; they are not passed in.
+
+### Section generators share no state
+
+Each returns a string and none can see what another emitted, so "was this
+type ever generated?" and "did two sections pick the same identifier?" have
+nowhere to live. That is the shape (see `docs/decisions.md`), and it is where
+#33 and #44 came from. A cross-section check needs the fact threaded in from
+`Rpc.Codegen`, not looked up inside a generator: #52 fixed #44 by passing
+`ResourceSchemas.generate_data_class/2` the set of resources the same pass
+emits a class for. Follow that pattern.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Generate type-safe Kotlin Multiplatform clients from your Ash resources.
 > recommended for production use. Please report issues and feedback on
 > [GitHub](https://github.com/udin-io/ash_kotlin_multiplatform/issues).
 
+[**docs/PROJECT.md**](docs/PROJECT.md) is the source of truth for what this
+library is, how it is built, where it is going and what is at risk. Start
+there rather than here if you are joining the project.
+
 ## Features
 
 - **Automatic Kotlin Multiplatform generation** from Elixir Ash resources

--- a/README.md
+++ b/README.md
@@ -401,18 +401,54 @@ When `generate_phoenix_channel_client: true`, the generator creates a full
 Phoenix Channel client:
 
 ```kotlin
-// Connect to Phoenix Channel
-val channel = AshRpcChannel(
-    httpClient = client,
-    baseUrl = "ws://localhost:4000/socket/websocket"
+val socket = PhoenixSocket(client, "ws://localhost:4000/socket/websocket")
+socket.connect()
+
+val channel = AshRpcChannel(socket, "rpc:lobby")
+channel.join()
+
+val result = channel.call(
+    action = "create_todo",
+    input = mapOf("title" to "Ship it"),
+    fields = listOf("id", "title")
 )
-
-// Join the RPC topic
-channel.join("rpc:lobby")
-
-// Make RPC calls over WebSocket
-val result = channel.call<CreateTodoResult>("create_todo", config)
 ```
+
+The client speaks Phoenix's v2 protocol and appends `vsn=2.0.0` on connect.
+The stock Phoenix socket offers v1 and v2, so nothing needs configuring; a
+host that narrowed its `serializer:` option to v1 only must add v2.
+
+### Binary payloads
+
+`pushBinary` sends raw bytes — an image frame, an audio chunk, a file —
+instead of base64 inside a JSON payload, which costs 33% more bytes on the
+wire and a second allocation on the server. The JSON path is unchanged.
+
+```kotlin
+// Send. The server sees {:binary, data} as the payload of handle_in/3.
+val push = channel.pushBinary("frame", jpegBytes)
+val (status, reply) = push.await()
+
+// Receive. Binary events bind separately from JSON ones, so `on` keeps its
+// JsonElement callback.
+channel.onBinary("frame") { bytes -> render(bytes) }
+```
+
+On the server:
+
+```elixir
+def handle_in("frame", {:binary, data}, socket) do
+  {:reply, {:ok, %{bytes: byte_size(data)}}, socket}
+end
+```
+
+A reply is JSON or binary independently of what was pushed. Use `await()`
+for a JSON reply, `awaitBinary()` for `{:reply, {:ok, {:binary, data}}}`,
+and `awaitPayload()` when the server can send either.
+
+`join_ref`, `ref`, `topic` and `event` are each length-prefixed with a
+single byte in a binary frame, so a topic or event name over 255 bytes
+raises rather than truncating.
 
 ## Advanced Features
 

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -1,0 +1,42 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# ash_kotlin_multiplatform
+
+This is the hub for everything a new reader needs to know about this
+repository. It was written on 2026-09-09, on first contact, because the
+repository had no source of truth at all and issue #49 asked for one before
+any further change. Each page below answers one question; this page says
+which page answers which, and what state that page is in.
+
+## What the system is
+
+An Elixir library that reads Ash resources and domains at compile time and
+writes a client for them: one `AshRpc.kt` file of Kotlin, and a parallel
+Swift generator. The generated client carries the resource data classes, the
+per-action input and result types, an HTTP RPC function per action, and a
+Phoenix Channel client. The library also ships the server half — a Phoenix
+controller and an action runner — so the same Ash domain answers the
+requests the generated client makes. It is alpha software; the API changes
+between versions.
+
+## The pages
+
+| Page | Answers | Status |
+| ---- | ------- | ------ |
+| [architecture.md](architecture.md) | How a resource becomes Kotlin and Swift, and what runs at request time | Current as of #49 |
+| [decisions.md](decisions.md) | The choices that still shape the code, and what each cost | Current as of #49 |
+| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | Current as of #49 |
+| [roadmap.md](roadmap.md) | What shipped, what is in flight, what is next, what was refused | Current as of #49 |
+
+## Keeping it current
+
+These pages describe the default branch as it is right now. A page that lags
+is worse than no page, because readers trust it. So: every PR that changes
+behaviour, structure, a risk or a decision updates them in the same PR. Move
+the roadmap item, redraw the diagram the change touched, add or retire the
+risk it created or removed, record the decision it made. A merge is not
+finished until these pages describe `main`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,166 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# Architecture
+
+How an Ash resource becomes a Kotlin or Swift client, and what runs when
+that client makes a call. Drawn on 2026-09-09 from the modules that exist in
+`lib/`, not from the README, as the source of truth issue #49 asked for.
+Read [PROJECT.md](PROJECT.md) first for what the library is. Update the
+diagram in the same PR as any change that adds, removes or re-points a
+module.
+
+## 1. Context
+
+Two audiences, one shared Ash domain. A developer runs a mix task to write
+the client; a mobile app then calls the server the library also provides.
+
+```mermaid
+C4Context
+    Person(dev, "Elixir developer", "Runs the codegen task, checks the output in")
+    Person(mobile, "Mobile developer", "Consumes AshRpc.kt / AshRpc.swift")
+
+    System(akm, "ash_kotlin_multiplatform", "Reads Ash resources; writes a Kotlin and a Swift client; serves the RPC requests that client makes")
+
+    System_Ext(host, "Host Phoenix app", "Owns the Ash domain, the router, the endpoint and any channel modules")
+    System_Ext(ash, "Ash + AshIntrospection", "Resource introspection, the shared RPC pipeline, field formatting")
+    System_Ext(app, "Android / iOS app", "Ktor or URLSession over HTTP and WebSocket")
+
+    Rel(dev, akm, "mix ash_kotlin_multiplatform.codegen")
+    Rel(akm, ash, "Ash.Info.domains/1, Spark DSL introspection")
+    Rel(akm, host, "Extensions on domains and resources; a controller to forward to")
+    Rel(mobile, app, "Builds against the generated client")
+    Rel(app, host, "POST /rpc/run, WebSocket /socket")
+    Rel(host, akm, "Phoenix.Controller delegation")
+```
+
+## 2. Containers
+
+The library is one OTP application with two halves that never call each
+other. The write half runs at development time and produces text. The serve
+half runs at request time inside the host's Phoenix app. They meet only in
+the wire contract the generated client encodes.
+
+```mermaid
+C4Container
+    System_Boundary(akm, "ash_kotlin_multiplatform") {
+        Container(tasks, "Mix tasks", "Elixir", "codegen, swift_codegen; writes one file each")
+        Container(kgen, "Kotlin generator", "Elixir", "AshKotlinMultiplatform.Rpc.Codegen and its type/function generators")
+        Container(sgen, "Swift generator", "Elixir", "AshKotlinMultiplatform.Swift.Codegen; a partial parallel of the Kotlin one")
+        Container(dsl, "DSL extensions", "Spark", "AshKotlinMultiplatform.Resource on resources, .Rpc on domains, plus four verifiers")
+        Container(serve, "RPC server half", "Elixir", "Phoenix.Controller, Rpc.Runner, Rpc.Pipeline, Rpc.Hooks")
+    }
+
+    Container_Ext(gate, "Kotlin compile gate", "Gradle + Kotlin 2.4.20", "test/fixtures/kotlin_compile; hands the emitted Kotlin to a real compiler in CI")
+    System_Ext(ash, "Ash + AshIntrospection", "")
+    System_Ext(client, "Generated client", "Kotlin / Swift", "AshRpc.kt, AshRpc.swift")
+
+    Rel(tasks, kgen, "generate_kotlin_code/2")
+    Rel(tasks, sgen, "generate_swift_code/2")
+    Rel(kgen, dsl, "reads rpc_actions, type_name, field_names")
+    Rel(sgen, dsl, "reads the same DSL")
+    Rel(kgen, client, "writes AshRpc.kt")
+    Rel(sgen, client, "writes AshRpc.swift")
+    Rel(gate, kgen, "compiles what it emits, one subproject per datetime_library")
+    Rel(client, serve, "POST /rpc/run, /rpc/validate")
+    Rel(serve, ash, "Ash action through the shared pipeline")
+```
+
+The compile gate is drawn because it is the only thing in the repository
+that checks the product. Everything else asserts on strings.
+
+## 3. Component: the Kotlin generator
+
+`Rpc.Codegen.generate_kotlin_code/2` is the only entry point. It collects
+config, runs the verifiers, then concatenates section generators in a fixed
+order and joins them into one file. Every generator returns a string; none
+of them share state.
+
+```mermaid
+flowchart TD
+    task["Mix.Tasks.AshKotlinMultiplatform.Codegen"] --> cg["Rpc.Codegen.generate_kotlin_code/2"]
+
+    cg --> coll["Rpc.Codegen.RpcConfigCollector<br/>reads Rpc.Info off each domain"]
+    cg --> vc["VerifierChecker<br/>VerifyIdentities, VerifyActionTypes,<br/>VerifyFieldNames, VerifyUniqueTypeNames"]
+
+    coll --> tuples["{resource, action, rpc_action}"]
+
+    tuples --> static["KotlinStatic<br/>imports, type aliases,<br/>HttpClient factory, error and result types"]
+    tuples --> schemas["Codegen.ResourceSchemas<br/>data classes, enums,<br/>sealed unions, embedded"]
+    tuples --> types["TypeGenerators.*<br/>InputTypes, ResultTypes,<br/>MetadataTypes, PaginationTypes"]
+    tuples --> filters["Codegen.FilterTypes<br/>Codegen.TypedQueries"]
+    tuples --> fns["FunctionGenerators.HttpRenderer<br/>+ FunctionCore, ConfigBuilder,<br/>ActionIntrospection, PayloadBuilder"]
+    tuples --> chan["Rpc.Codegen.PhoenixChannel<br/>PhoenixMessage, PhoenixSocket,<br/>PhoenixChannel, AshRpcChannel"]
+
+    schemas --> tm["Codegen.TypeMapper<br/>Codegen.TypeDiscovery"]
+    types --> tm
+    filters --> tm
+
+    static --> out["AshRpc.kt"]
+    schemas --> out
+    types --> out
+    filters --> out
+    fns --> out
+    chan --> out
+```
+
+Two things about `PhoenixChannel` that the box does not show. It is
+**static**: it takes no resource and no action, so the same text is emitted
+for every application, which is issue #35. And it is the only generated code
+that owns a wire format of its own rather than delegating to
+kotlinx.serialization — see the decision on the v2 serializer.
+
+## 4. Component: the request path
+
+The generated Kotlin has two ways to reach an Ash action, and they converge.
+The channel leg is only half in this repository: the library generates the
+client but ships no `Phoenix.Channel` module, so the host writes the
+`handle_in` that calls `Rpc.Runner`.
+
+```mermaid
+sequenceDiagram
+    participant App as Android app
+    participant Ctl as Phoenix.Controller
+    participant Ch as Host channel module
+    participant Run as Rpc.Runner
+    participant Pipe as Rpc.Pipeline
+    participant Ash as Ash domain
+
+    App->>Ctl: POST /rpc/run {action, input, fields}
+    Ctl->>Run: run_action(otp_app, params, actor:, tenant:)
+    Run->>Pipe: parse_request, execute, format_output
+    Pipe->>Ash: Ash.read / create / update / destroy
+    Ash-->>Pipe: records
+    Pipe-->>Run: field-selected map
+    Run-->>Ctl: %{success: true, data: ...}
+    Ctl-->>App: JSON
+
+    Note over App,Ch: The channel leg. The host owns the channel module.
+    App->>Ch: push "rpc" (text) or a binary frame
+    Ch->>Run: run_action/3
+    Run-->>Ch: result map
+    Ch-->>App: phx_reply
+```
+
+## 5. The Phoenix channel wire format
+
+The generated channel client speaks Phoenix's **v1** serializer,
+`Phoenix.Socket.V1.JSONSerializer`. Nothing chose it: the socket sends no
+`vsn` query parameter, and `deps/phoenix/lib/phoenix/socket.ex:499` defaults
+an absent `vsn` to `"1.0.0"`, which
+`deps/phoenix/lib/phoenix/transports/websocket.ex:29` matches to v1. The
+generated `PhoenixMessage` is a `@Serializable` data class, so it encodes to
+the JSON object v1 expects:
+
+```
+{"join_ref": ..., "ref": ..., "topic": ..., "event": ..., "payload": ...}
+```
+
+The `PhoenixChannel` module's own docstring claims v2. It is wrong, and the
+gap is not cosmetic: v1's `decode!/2` JSON-decodes whatever arrives and has
+no binary branch at all, so no binary frame can reach a channel over this
+client. That is issue #49.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,7 @@ flowchart TD
     tuples --> types["TypeGenerators.*<br/>InputTypes, ResultTypes,<br/>MetadataTypes, PaginationTypes"]
     tuples --> filters["Codegen.FilterTypes<br/>Codegen.TypedQueries"]
     tuples --> fns["FunctionGenerators.HttpRenderer<br/>+ FunctionCore, ConfigBuilder,<br/>ActionIntrospection, PayloadBuilder"]
-    tuples --> chan["Rpc.Codegen.PhoenixChannel<br/>PhoenixMessage, PhoenixSocket,<br/>PhoenixChannel, AshRpcChannel"]
+    tuples --> chan["Rpc.Codegen.PhoenixChannel<br/>PhoenixSerializer, PhoenixSocket,<br/>PhoenixChannel, AshRpcChannel"]
 
     schemas --> tm["Codegen.TypeMapper<br/>Codegen.TypeDiscovery"]
     types --> tm
@@ -147,20 +147,40 @@ sequenceDiagram
 
 ## 5. The Phoenix channel wire format
 
-The generated channel client speaks Phoenix's **v1** serializer,
-`Phoenix.Socket.V1.JSONSerializer`. Nothing chose it: the socket sends no
-`vsn` query parameter, and `deps/phoenix/lib/phoenix/socket.ex:499` defaults
-an absent `vsn` to `"1.0.0"`, which
-`deps/phoenix/lib/phoenix/transports/websocket.ex:29` matches to v1. The
-generated `PhoenixMessage` is a `@Serializable` data class, so it encodes to
-the JSON object v1 expects:
+The generated channel client speaks Phoenix's **v2** serializer,
+`Phoenix.Socket.V2.JSONSerializer`, selected by the `vsn=2.0.0` query
+parameter the socket appends on connect. The negotiation is in
+`deps/phoenix/lib/phoenix/socket.ex:499` and the serializer list in
+`deps/phoenix/lib/phoenix/transports/websocket.ex:29`. Absent a `vsn`,
+Phoenix falls back to v1, which has no binary branch at all — that is what
+the client did before #49, unmarked.
+
+Text frames are a five-element JSON array, not an object:
 
 ```
-{"join_ref": ..., "ref": ..., "topic": ..., "event": ..., "payload": ...}
+[join_ref, ref, topic, event, payload]
 ```
 
-The `PhoenixChannel` module's own docstring claims v2. It is wrong, and the
-gap is not cosmetic: v1's `decode!/2` JSON-decodes whatever arrives and has
-no binary branch at all, so no binary frame can reach a channel over this
-client. That is issue #49.
+Binary frames are length-prefixed, and the layout differs by direction and
+kind. Every length is one unsigned byte, so each of those strings is capped
+at 255 bytes.
+
+| Direction | Kind | Header bytes | Fields after the header |
+| --------- | ---- | ------------ | ----------------------- |
+| Client to server | `0` push | `0`, joinRefLen, refLen, topicLen, eventLen | joinRef, ref, topic, event, data |
+| Server to client | `0` push | `0`, joinRefLen, topicLen, eventLen | joinRef, topic, event, data (no ref) |
+| Server to client | `1` reply | `1`, joinRefLen, refLen, topicLen, statusLen | joinRef, ref, topic, status, data |
+| Server to client | `2` broadcast | `2`, topicLen, eventLen | topic, event, data (no refs) |
+
+The outgoing push carries a ref and the incoming push does not, and a reply
+puts its status where a push puts its event name. A client that reuses one
+layout for both directions misreads every field, and the result is frames
+the server drops in silence.
+
+Both directions are emitted by `Rpc.Codegen.PhoenixChannel` as the generated
+`PhoenixSerializer` object. The Elixir half of the contract is asserted byte
+for byte in
+`test/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel_test.exs`,
+against the same `Phoenix.Socket.V2.JSONSerializer` that will decode the
+frames.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -1,0 +1,102 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# Decisions
+
+The choices that still shape this code, one dated entry each: what was
+decided, why, and what it cost. Reconstructed on 2026-09-09 from the commit
+history and the code, as the source of truth issue #49 asked for. This file
+replaces an ADR directory; git is already the journal, so a decision that no
+longer shapes anything gets deleted rather than marked superseded. Add an
+entry in the same PR as the change that makes the decision.
+
+## 2025-12-20 — Mirror ash_typescript's modular codegen shape
+
+Section generators, one module each, each returning a string, concatenated
+in a fixed order by `Rpc.Codegen`. Chosen because `ash_typescript` had
+already proven the shape and the port could follow it module for module.
+
+Cost: the generators share no state, so anything that spans sections —
+knowing that a referenced type was never emitted, or that two sections
+picked the same Kotlin identifier — has no place to live. #33 and #44 both
+came from that gap. The fix each time is to thread the fact in from
+`Rpc.Codegen` rather than look it up in a generator.
+
+## 2025-12-21 — Ship a Swift generator alongside the Kotlin one
+
+`Swift.Codegen` and `Swift.TypeMapper` were added in the same release as the
+Phoenix controller.
+
+Cost: it is half a generator. It has two test files against the Kotlin
+side's dozen, it is not in the compile gate, and no CI job compiles Swift at
+all. Issue #31 is open on whether to finish it or delete it.
+
+## 2026-09-09 — Depend on AshIntrospection for the shared RPC core
+
+`Rpc.Pipeline` is a thin Kotlin-flavoured wrapper over
+`AshIntrospection.Rpc.Pipeline`; `Rpc.Runner` and the field formatters go
+through the same package.
+
+Why: field selection, error shaping and formatter rules are identical across
+the TypeScript, Kotlin and Swift clients, and three copies would drift.
+
+Cost: a bug in the shared core lands here as a bug in this library with no
+local fix. Issue #48 is one — the runner reaches for the type-blind
+`format_output/2`.
+
+## 2026-09-09 — Raise dependency floors to the newest patched release
+
+`mix.exs` pins `ash ~> 3.33`, `ash_phoenix >= 2.3.25`, `phoenix >= 1.8.9`,
+`plug >= 1.19.5`, each annotated with the CVEs it clears.
+
+Why: a library's floor is what every consumer inherits, so a low floor
+silently permits a vulnerable transitive version in an app that never
+audited it.
+
+Cost: consumers on older Ash cannot upgrade this library without upgrading
+Ash first. Accepted while the package is alpha.
+
+## 2026-09-09 — Compile the generated Kotlin in CI, and block on it
+
+`test/fixtures/kotlin_compile` is a Gradle project with one subproject per
+`datetime_library` setting; the `kotlin-compile-gate` job runs
+`gradle compileKotlin`. It shipped with `continue-on-error: true` because the
+generated Kotlin did not compile, and lost it in #52 once the sixteen errors
+it found (#44, #45) were fixed.
+
+Why: this library's entire product is Kotlin source and nothing had ever
+compiled it. Five "does not compile" defects had all been found by a human
+reading emitted strings.
+
+Cost: CI now needs a JDK and a Gradle, and the gate only compiles what the
+test domain's resources produce. A generated shape no test resource has is
+still unchecked.
+
+## 2026-09-09 — An unpublished relationship is dropped, not generated
+
+`Author` has a public `has_many :secrets` to a resource the Kotlin DSL never
+publishes. `ResourceSchemas.generate_data_class/2` now omits the field
+rather than emitting `List<Secret>` against a class that exists nowhere.
+
+Why: the server already refuses it. `Rpc.Runner`'s field selector gates on
+`Resource.Info.kotlin_multiplatform_resource?/1`, so a nested request into
+`Author.secrets` comes back `unknown_field`. A field no round trip can
+deliver is worth nothing to a client. Generating the missing type would
+contradict the DSL, and a verifier error would turn any public Ash
+relationship into a build break.
+
+Cost: the omission is silent. A developer who expects the field has to know
+the destination must carry the `kotlin_multiplatform` extension.
+
+## 2026-09-09 — Contextual serializers for every Kotlin `Any`
+
+Untyped maps, keywords, tuples, unions and unmapped Ash types all landed on
+a bare `Any` inside `@Serializable` classes, which does not compile.
+`@Contextual` defers the lookup to the `SerializersModule`.
+
+Cost: the failure moves from compile time to run time. Issue #51 is exactly
+that: the code now compiles and a populated untyped map still fails to
+decode.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -91,6 +91,37 @@ relationship into a build break.
 Cost: the omission is silent. A developer who expects the field has to know
 the destination must carry the `kotlin_multiplatform` extension.
 
+## 2026-09-09 — The channel client owns Phoenix's v2 format by hand
+
+`PhoenixMessage` lost `@Serializable`; the generated `PhoenixSerializer`
+encodes text frames as the JSON array v2 expects and the socket sends
+`vsn=2.0.0`.
+
+Why: a `@Serializable` data class can only emit a JSON object, which is the
+v1 shape, and v1's serializer has no binary frame at all. Binary payloads
+(#49) are impossible without v2, and v2's text frame is an array.
+
+Cost: the client now hand-writes a format that lives in the `phoenix`
+package, so a Phoenix change to it is invisible here. The mitigation is a
+test block asserting the format against `Phoenix.Socket.V2.JSONSerializer`
+itself, and it is the reason that risk is written down.
+
+## 2026-09-09 — A separate `pushBinary`, not a widened payload type
+
+`channel.push(event, jsonElement)` is unchanged; `channel.pushBinary(event,
+byteArray)` is new. `Push.payload` became a `ChannelPayload` so it stops
+claiming a binary push carried JSON, but its `JsonElement` constructor and
+its `await()`/`receive()` signatures are kept.
+
+Why: the JSON path is every existing user of this library. Widening
+`push`'s parameter to a sealed type would have made the common call read
+`push(event, ChannelPayload.Json(x))` — a worse API for everyone, to serve
+the rarer case.
+
+Cost: two lanes to keep in step. `await()` returns null for a reply the
+server sent as binary, and `awaitBinary()` returns null for a JSON one;
+`awaitPayload()` is the one that never hides a reply.
+
 ## 2026-09-09 — Contextual serializers for every Kotlin `Any`
 
 Untyped maps, keywords, tuples, unions and unmapped Ash types all landed on

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -47,16 +47,30 @@ same `{resource, action, rpc_action}` tuples the HTTP renderer uses.
 
 ### The client owns a wire format it does not share with the server
 
-The channel client hand-writes Phoenix's serializer format in Kotlin. The
-Elixir side of that format lives in the `phoenix` package, not here, so a
-Phoenix change to it is invisible to this repository's test suite.
+The channel client hand-writes Phoenix's v2 serializer format in Kotlin —
+four binary layouts and a text array. The Elixir side of that format lives
+in the `phoenix` package, not here, so a Phoenix change to it would
+otherwise be invisible to this repository.
 
-*Watch:* the wire-format assertions in `phoenix_channel_test.exs` name the
-Phoenix file and version they were verified against.
+*Watch:* the `the Phoenix v2 wire format the generated client is written
+against` block in `phoenix_channel_test.exs`. It asserts each layout against
+`Phoenix.Socket.V2.JSONSerializer` itself and names the Phoenix version it
+was verified on.
 *Do:* on a Phoenix major bump, re-read
-`deps/phoenix/lib/phoenix/socket/serializers/` and re-check those
-assertions. A mismatch produces frames the server drops in silence, with no
-error on either side.
+`deps/phoenix/lib/phoenix/socket/serializers/v2_json_serializer.ex` and
+update both the assertions and the generated Kotlin together. A mismatch
+produces frames the server drops in silence, with no error on either side.
+
+### The v2 switch changes the wire for every existing consumer
+
+The socket now sends `vsn=2.0.0` and frames text as a JSON array. Any
+consumer on an older generated client keeps talking v1 and is unaffected,
+but a regenerated client will not work against a server whose socket
+declares only the v1 serializer.
+
+*Watch:* the alpha notice, and the CHANGELOG entry naming this as breaking.
+*Do:* nothing for the stock Phoenix socket, which offers both. A host that
+narrowed `serializer:` to v1 must add v2.
 
 ### `main` is not formatter-clean
 

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -1,0 +1,103 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# Risks
+
+What could go wrong in this library, what we watch for it, and what we would
+do. Written on 2026-09-09 as part of the source of truth issue #49 asked
+for. A PR that creates a risk adds it here; a PR that removes one deletes
+the entry rather than marking it closed.
+
+## Technical
+
+### The product is text, and most tests assert on text
+
+Every generator returns a string and most tests are `assert result =~ "..."`.
+A test can pass on Kotlin that does not compile, and did — #20, #23, #24,
+#30 and #33 were all found by a human reading emitted strings.
+
+*Watch:* the `kotlin-compile-gate` CI job, blocking and green since #52.
+*Do:* run it locally before pushing any generator change. Its green is only
+worth what it covers: it compiles the test domain's resources, so a shape no
+test resource has is still unchecked.
+
+### Swift is generated and never compiled
+
+`Swift.Codegen` is 742 lines with two test files and no compiler anywhere in
+CI. Whatever the Kotlin gate found in the Kotlin generator is likely true of
+the Swift one, unobserved.
+
+*Watch:* nothing watches it today.
+*Do:* decide #31 — finish it with a compile gate of its own, or delete it.
+Half a generator that nobody compiles is worse than neither.
+
+### The channel client is static
+
+`Rpc.Codegen.PhoenixChannel` takes no resource and no action; the same text
+is emitted for every application. It cannot express a per-action payload, a
+typed event, or anything the DSL knows (#35).
+
+*Watch:* every channel feature request lands as a change to one hardcoded
+string.
+*Do:* if channel use grows past `AshRpcChannel.call/5`, drive it from the
+same `{resource, action, rpc_action}` tuples the HTTP renderer uses.
+
+### The client owns a wire format it does not share with the server
+
+The channel client hand-writes Phoenix's serializer format in Kotlin. The
+Elixir side of that format lives in the `phoenix` package, not here, so a
+Phoenix change to it is invisible to this repository's test suite.
+
+*Watch:* the wire-format assertions in `phoenix_channel_test.exs` name the
+Phoenix file and version they were verified against.
+*Do:* on a Phoenix major bump, re-read
+`deps/phoenix/lib/phoenix/socket/serializers/` and re-check those
+assertions. A mismatch produces frames the server drops in silence, with no
+error on either side.
+
+### `main` is not formatter-clean
+
+`mix format --check-formatted` fails on ten files that predate the current
+rules, so the check cannot go into CI (#38) and formatting drift is invisible
+in review.
+
+*Watch:* nothing.
+*Do:* close #38 as one mechanical commit, then add the check to the `test`
+job.
+
+## Operational
+
+### Two generators, one hex release, alpha API
+
+The README advertises Kotlin, Swift, filters, pagination and validation. Not
+all of it works, and the package is on hex where anyone can depend on it.
+
+*Watch:* the alpha notice at the top of the README and in `mix.exs`.
+*Do:* keep the notice until #22, #24 and #31 close. Do not cut a release
+that quietly widens what is claimed.
+
+### The compile gate needs a JDK and a Gradle that CI installs each run
+
+The fixture has no committed wrapper, so a local run needs JDK 21 and Gradle
+9.7 on the path, and CI resolves the Kotlin and Ktor artifacts from Maven
+Central.
+
+*Watch:* the `kotlin-compile-gate` job's setup steps.
+*Do:* if Maven Central flakiness starts failing the job, cache the
+dependency jars rather than committing a wrapper.
+
+## Product
+
+### The generated client returns an untyped result
+
+`RpcResult` is untyped and the generated per-action result types are
+orphaned (#22), so the end-to-end type safety the README leads with stops at
+the response boundary.
+
+*Watch:* #22, and #24 alongside it — the client cannot decode the server's
+own error shape either.
+*Do:* fix them together. Typed success with untyped failure is not type
+safety.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,12 +28,11 @@ afterwards.
 | 2026-09-09 | The Kotlin compile gate: a Gradle fixture and a CI job (#37, PR #47) |
 | 2026-09-09 | Generated Kotlin compiles for map, union and unmapped types (PR #50) |
 | 2026-09-09 | The generated Kotlin compiles and the gate enforces it (#44, #45, #46) |
+| 2026-09-09 | This source of truth, the v2 channel protocol, and binary channel payloads (#49) |
 
 ## In progress
 
-| Issue | What |
-| ----- | ---- |
-| #49 | Binary payloads over the generated Phoenix channel client, and this source of truth |
+Nothing.
 
 ## Next
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+
+SPDX-License-Identifier: MIT
+-->
+
+# Roadmap
+
+Where the library has been and where it is going. Reconstructed on
+2026-09-09 from `git log` and the open issues, as the source of truth issue
+#49 asked for. Move an item here in the same PR that merges it, not
+afterwards.
+
+## Shipped
+
+| When | What |
+| ---- | ---- |
+| 2025-12-20 | First cut: the RPC pipeline, hooks, and the resource and domain DSL extensions |
+| 2025-12-21 | Modular codegen architecture mirroring `ash_typescript` (#1) |
+| 2025-12-21 | Swift generator and the Phoenix RPC controller (#5); released as 0.1.2 and 0.1.3 |
+| 2026-09-07 | `Instant` serialization across kotlinx-datetime versions (#10) |
+| 2026-09-07 | Base filter types routed through `TypeMapper` so `datetime_library` reaches them (#14) |
+| 2026-09-07 | `Rpc.Runner` honours the `metadataFields` the client sends (#15) |
+| 2026-09-07 | Removed the unwired `ValidationSchemas` module and its dead `javax.validation` import (#16) |
+| 2026-09-09 | CI: compile, test and dependency audit (#40) |
+| 2026-09-09 | Fixed atom exhaustion and 500s in RPC field selection (#18, #19) |
+| 2026-09-09 | Dependency floors raised past 34 advisories (#42) |
+| 2026-09-09 | The Kotlin compile gate: a Gradle fixture and a CI job (#37, PR #47) |
+| 2026-09-09 | Generated Kotlin compiles for map, union and unmapped types (PR #50) |
+| 2026-09-09 | The generated Kotlin compiles and the gate enforces it (#44, #45, #46) |
+
+## In progress
+
+| Issue | What |
+| ----- | ---- |
+| #49 | Binary payloads over the generated Phoenix channel client, and this source of truth |
+
+## Next
+
+Ordered by what unblocks the most.
+
+| Issue | What | Why now |
+| ----- | ---- | ------- |
+| #38 | Make `main` formatter-clean and put the check in CI | One mechanical commit; unblocks review signal |
+| #22, #24 | Typed results, and decoding the server's own error shape | The type safety the README leads with |
+| #51, #48 | Untyped maps fail to decode; the runner mangles unconstrained map keys | The runtime half of the `@Contextual` trade |
+| #17, #43 | Unstable output order across builds | A regenerated file should diff empty |
+| #35 | The channel client is static and cannot send most params | Blocks any per-action channel work |
+| #31 | Decide the fate of the half-built Swift generator | It is generated and never compiled |
+
+## Decided against
+
+Nothing yet. When something is refused, record it here with the reason, so
+the next reader does not re-propose it.

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel.ex
@@ -4,24 +4,45 @@
 
 defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
   @moduledoc """
-  Generates Kotlin Phoenix Channel client code.
+  Generates the Kotlin Phoenix Channel client: connection management with
+  reconnection and heartbeats, channel join and leave, the push/receive
+  pattern, and an `AshRpcChannel` wrapper for RPC actions.
 
-  This module generates a complete Phoenix Channel implementation for Kotlin
-  that supports:
-  - WebSocket connection management with automatic reconnection
-  - Phoenix protocol message format (v2)
-  - Heartbeat handling
-  - Channel join/leave with callbacks
-  - Push/receive pattern for messages
-  - RPC-specific convenience methods
+  ## The wire format is owned here, not by kotlinx.serialization
+
+  The client speaks Phoenix's **v2** protocol, `Phoenix.Socket.V2.JSONSerializer`.
+  That is a deliberate choice with two consequences the rest of the generated
+  code does not have, and getting either wrong produces frames the server drops
+  in silence:
+
+  * The socket appends `vsn=2.0.0` on connect. Phoenix defaults an absent `vsn`
+    to `"1.0.0"` (`phoenix/lib/phoenix/socket.ex`, `__connect__/3`), and the v1
+    serializer has no binary branch at all, so a binary payload is impossible
+    without this. Before issue #49 the client sent no `vsn` and was, unmarked, a
+    v1 client.
+  * A v2 text frame is the JSON **array** `[join_ref, ref, topic, event, payload]`.
+    A `@Serializable` data class would emit an object, which is the v1 shape, so
+    `PhoenixMessage` is encoded by hand in the generated `PhoenixSerializer`.
+
+  Verified against Phoenix 1.8.13:
+  `phoenix/lib/phoenix/socket/serializers/v2_json_serializer.ex` (`encode!/1`,
+  `decode_binary/1`) and `phoenix/assets/js/phoenix/serializer.js`. The Elixir
+  half of that contract is asserted in
+  `test/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel_test.exs`, because
+  it lives in another package and can change without this repository noticing.
   """
 
   @doc """
   Generates the complete Phoenix Channel client code for Kotlin.
+
+  Returns one string of top-level Kotlin declarations. Takes no resource and no
+  action: the same text is emitted for every application (issue #35).
   """
   def generate do
     """
     #{generate_phoenix_message()}
+
+    #{generate_phoenix_serializer()}
 
     #{generate_channel_state()}
 
@@ -41,10 +62,13 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
 
   defp generate_phoenix_message do
     """
-    // Phoenix Protocol Message
-    @Serializable
+    // A Phoenix protocol message with a JSON payload.
+    //
+    // Deliberately not @Serializable: a v2 text frame is the JSON array
+    // [join_ref, ref, topic, event, payload], and kotlinx.serialization would
+    // emit this as an object, which is the v1 shape. PhoenixSerializer builds
+    // the array.
     data class PhoenixMessage(
-        @SerialName("join_ref")
         val joinRef: String?,
         val ref: String?,
         val topic: String,
@@ -69,6 +93,57 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             fun push(topic: String, joinRef: String?, ref: String, event: String, payload: JsonElement) =
                 PhoenixMessage(joinRef = joinRef, ref = ref, topic = topic, event = event, payload = payload)
         }
+    }
+    """
+  end
+
+  defp generate_phoenix_serializer do
+    """
+    /**
+     * Phoenix's v2 wire protocol.
+     *
+     * Text frames are the JSON array [join_ref, ref, topic, event, payload],
+     * not the object v1 used. The Phoenix source this was read from is in the
+     * generator's moduledoc.
+     */
+    object PhoenixSerializer {
+        // Sent as the `vsn` query parameter. Phoenix defaults an absent vsn to
+        // "1.0.0", and the v1 serializer has no binary frame at all.
+        const val VSN = "2.0.0"
+
+        fun encodeText(message: PhoenixMessage): String =
+            JsonArray(
+                listOf(
+                    jsonString(message.joinRef),
+                    jsonString(message.ref),
+                    jsonString(message.topic),
+                    jsonString(message.event),
+                    message.payload
+                )
+            ).toString()
+
+        fun decodeText(text: String): PhoenixMessage {
+            val fields = Json.parseToJsonElement(text) as? JsonArray
+                ?: throw IllegalArgumentException("Phoenix v2 text frame is not a JSON array")
+
+            require(fields.size >= 5) {
+                "Phoenix v2 text frame needs 5 elements, got ${fields.size}"
+            }
+
+            return PhoenixMessage(
+                joinRef = stringOrNull(fields[0]),
+                ref = stringOrNull(fields[1]),
+                topic = stringOrNull(fields[2]) ?: "",
+                event = stringOrNull(fields[3]) ?: "",
+                payload = fields[4]
+            )
+        }
+
+        private fun jsonString(value: String?): JsonElement =
+            if (value == null) JsonNull else JsonPrimitive(value)
+
+        private fun stringOrNull(element: JsonElement): String? =
+            if (element is JsonPrimitive && element != JsonNull) element.content else null
     }
     """
   end
@@ -123,7 +198,6 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
         private var status: PushStatus? = null
         private val responseCallbacks = mutableMapOf<String, (JsonElement) -> Unit>()
         private var timeoutCallback: (() -> Unit)? = null
-        private val sent = kotlinx.coroutines.CompletableDeferred<Unit>()
         private val responded = kotlinx.coroutines.CompletableDeferred<Pair<PushStatus, JsonElement?>>()
 
         fun receive(status: String, callback: (JsonElement) -> Unit): Push {
@@ -210,7 +284,6 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
         private var onCloseCallbacks = mutableListOf<(Int, String) -> Unit>()
         private var onErrorCallbacks = mutableListOf<(Throwable) -> Unit>()
         private var onMessageCallbacks = mutableListOf<(PhoenixMessage) -> Unit>()
-        private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
         private val scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO + kotlinx.coroutines.SupervisorJob())
 
         fun generateRef(): String = (++refCounter).toString()
@@ -277,7 +350,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
         }
 
         internal suspend fun push(message: PhoenixMessage) {
-            session?.send(io.ktor.websocket.Frame.Text(json.encodeToString(PhoenixMessage.serializer(), message)))
+            session?.send(io.ktor.websocket.Frame.Text(PhoenixSerializer.encodeText(message)))
         }
 
         internal fun registerPush(push: Push) {
@@ -288,10 +361,15 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             pendingPushes.remove(ref)
         }
 
+        // `vsn` selects the server's serializer, and Phoenix defaults an absent
+        // one to "1.0.0", whose serializer has no binary frame. It is set here
+        // rather than left to the caller, because the frames this client
+        // encodes are v2 either way.
         private fun buildUrl(): String {
             val separator = if (url.contains("?")) "&" else "?"
-            val queryParams = params.entries.joinToString("&") { "${it.key}=${it.value}" }
-            return if (queryParams.isNotEmpty()) "$url$separator$queryParams" else url
+            val allParams = params.filterKeys { it != "vsn" } + ("vsn" to PhoenixSerializer.VSN)
+            val queryParams = allParams.entries.joinToString("&") { "${it.key}=${it.value}" }
+            return "$url$separator$queryParams"
         }
 
         private fun startHeartbeat() {
@@ -320,8 +398,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
                                 is io.ktor.websocket.Frame.Text -> {
                                     val text = frame.readText()
                                     try {
-                                        val message = json.decodeFromString(PhoenixMessage.serializer(), text)
-                                        handleMessage(message)
+                                        handleMessage(PhoenixSerializer.decodeText(text))
                                     } catch (e: Exception) {
                                         onErrorCallbacks.forEach { it(e) }
                                     }
@@ -676,6 +753,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             channel.off(event)
             return this
         }
+
     }
     """
   end

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel.ex
@@ -24,6 +24,16 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
     A `@Serializable` data class would emit an object, which is the v1 shape, so
     `PhoenixMessage` is encoded by hand in the generated `PhoenixSerializer`.
 
+  Binary frames are length-prefixed with one unsigned byte per field, capping
+  each of `join_ref`, `ref`, `topic` and `event` at 255 bytes. The layouts are
+  **not symmetric** — a client-to-server push carries a ref and a
+  server-to-client push does not:
+
+      client -> server  push       [0][joinRefLen][refLen][topicLen][eventLen]  joinRef ref topic event data
+      server -> client  push       [0][joinRefLen][topicLen][eventLen]          joinRef topic event data
+      server -> client  reply      [1][joinRefLen][refLen][topicLen][statusLen] joinRef ref topic status data
+      server -> client  broadcast  [2][topicLen][eventLen]                      topic event data
+
   Verified against Phoenix 1.8.13:
   `phoenix/lib/phoenix/socket/serializers/v2_json_serializer.ex` (`encode!/1`,
   `decode_binary/1`) and `phoenix/assets/js/phoenix/serializer.js`. The Elixir
@@ -41,6 +51,10 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
   def generate do
     """
     #{generate_phoenix_message()}
+
+    #{generate_binary_message()}
+
+    #{generate_channel_payload()}
 
     #{generate_phoenix_serializer()}
 
@@ -97,19 +111,68 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
     """
   end
 
+  defp generate_binary_message do
+    """
+    /**
+     * A decoded incoming binary frame.
+     *
+     * Which fields are populated depends on the frame's kind, because Phoenix
+     * gives each kind a different header:
+     *
+     *  - a server push carries a joinRef but no ref;
+     *  - a broadcast carries neither;
+     *  - a reply carries both, plus a `status`, which sits where a push puts
+     *    its event name. `event` is then "phx_reply".
+     */
+    class PhoenixBinaryMessage(
+        val joinRef: String?,
+        val ref: String?,
+        val topic: String,
+        val event: String,
+        val status: String?,
+        val payload: ByteArray
+    )
+    """
+  end
+
+  defp generate_channel_payload do
+    """
+    /**
+     * What a push carried. Phoenix frames JSON and binary payloads differently,
+     * so the difference has to survive as far as the socket, and a reply can
+     * come back as either.
+     */
+    sealed class ChannelPayload {
+        data class Json(val element: JsonElement) : ChannelPayload()
+
+        // Not a data class: ByteArray equality is identity, so a generated
+        // equals() would claim two frames differ when they hold the same bytes.
+        class Binary(val bytes: ByteArray) : ChannelPayload()
+    }
+    """
+  end
+
   defp generate_phoenix_serializer do
     """
     /**
      * Phoenix's v2 wire protocol.
      *
-     * Text frames are the JSON array [join_ref, ref, topic, event, payload],
-     * not the object v1 used. The Phoenix source this was read from is in the
-     * generator's moduledoc.
+     * Text frames are the JSON array [join_ref, ref, topic, event, payload].
+     * Binary frames are length-prefixed, one unsigned byte per field, and the
+     * layout differs by direction and kind. Layouts and the Phoenix source they
+     * were read from are in this file's generator moduledoc.
      */
     object PhoenixSerializer {
         // Sent as the `vsn` query parameter. Phoenix defaults an absent vsn to
         // "1.0.0", and the v1 serializer has no binary frame at all.
         const val VSN = "2.0.0"
+
+        const val KIND_PUSH = 0
+        const val KIND_REPLY = 1
+        const val KIND_BROADCAST = 2
+
+        // Each header length is one unsigned byte.
+        const val MAX_FIELD_BYTES = 255
 
         fun encodeText(message: PhoenixMessage): String =
             JsonArray(
@@ -139,11 +202,137 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             )
         }
 
+        /**
+         * A client-to-server binary push.
+         *
+         *     [0][joinRefLen][refLen][topicLen][eventLen] joinRef ref topic event data
+         *
+         * The ref is what a reply comes back on, so it is required here even
+         * though the server's own push frames omit it.
+         */
+        fun encodeBinaryPush(joinRef: String, ref: String, topic: String, event: String, payload: ByteArray): ByteArray {
+            val joinRefBytes = joinRef.encodeToByteArray()
+            val refBytes = ref.encodeToByteArray()
+            val topicBytes = topic.encodeToByteArray()
+            val eventBytes = event.encodeToByteArray()
+
+            assertFieldSize(joinRefBytes.size, "join_ref")
+            assertFieldSize(refBytes.size, "ref")
+            assertFieldSize(topicBytes.size, "topic")
+            assertFieldSize(eventBytes.size, "event")
+
+            val headerSize = 5 + joinRefBytes.size + refBytes.size + topicBytes.size + eventBytes.size
+            val frame = ByteArray(headerSize + payload.size)
+
+            frame[0] = KIND_PUSH.toByte()
+            frame[1] = joinRefBytes.size.toByte()
+            frame[2] = refBytes.size.toByte()
+            frame[3] = topicBytes.size.toByte()
+            frame[4] = eventBytes.size.toByte()
+
+            var offset = 5
+            offset = write(joinRefBytes, frame, offset)
+            offset = write(refBytes, frame, offset)
+            offset = write(topicBytes, frame, offset)
+            offset = write(eventBytes, frame, offset)
+            write(payload, frame, offset)
+
+            return frame
+        }
+
+        /**
+         * A server-to-client binary frame. The kind byte picks the layout;
+         * mixing them up misreads every field, so each branch states its own.
+         */
+        fun decodeBinary(frame: ByteArray): PhoenixBinaryMessage {
+            require(frame.isNotEmpty()) { "Phoenix binary frame is empty" }
+
+            return when (val kind = unsigned(frame, 0)) {
+                KIND_PUSH -> {
+                    // [0][joinRefLen][topicLen][eventLen] joinRef topic event data
+                    val joinRefLen = unsigned(frame, 1)
+                    val topicLen = unsigned(frame, 2)
+                    val eventLen = unsigned(frame, 3)
+                    requireLength(frame, 4 + joinRefLen + topicLen + eventLen)
+
+                    var offset = 4
+                    val joinRef = frame.decodeToString(offset, offset + joinRefLen)
+                    offset += joinRefLen
+                    val topic = frame.decodeToString(offset, offset + topicLen)
+                    offset += topicLen
+                    val event = frame.decodeToString(offset, offset + eventLen)
+                    offset += eventLen
+
+                    PhoenixBinaryMessage(joinRef, null, topic, event, null, frame.copyOfRange(offset, frame.size))
+                }
+
+                KIND_REPLY -> {
+                    // [1][joinRefLen][refLen][topicLen][statusLen] joinRef ref topic status data
+                    val joinRefLen = unsigned(frame, 1)
+                    val refLen = unsigned(frame, 2)
+                    val topicLen = unsigned(frame, 3)
+                    val statusLen = unsigned(frame, 4)
+                    requireLength(frame, 5 + joinRefLen + refLen + topicLen + statusLen)
+
+                    var offset = 5
+                    val joinRef = frame.decodeToString(offset, offset + joinRefLen)
+                    offset += joinRefLen
+                    val ref = frame.decodeToString(offset, offset + refLen)
+                    offset += refLen
+                    val topic = frame.decodeToString(offset, offset + topicLen)
+                    offset += topicLen
+                    val status = frame.decodeToString(offset, offset + statusLen)
+                    offset += statusLen
+
+                    PhoenixBinaryMessage(joinRef, ref, topic, "phx_reply", status, frame.copyOfRange(offset, frame.size))
+                }
+
+                KIND_BROADCAST -> {
+                    // [2][topicLen][eventLen] topic event data
+                    val topicLen = unsigned(frame, 1)
+                    val eventLen = unsigned(frame, 2)
+                    requireLength(frame, 3 + topicLen + eventLen)
+
+                    var offset = 3
+                    val topic = frame.decodeToString(offset, offset + topicLen)
+                    offset += topicLen
+                    val event = frame.decodeToString(offset, offset + eventLen)
+                    offset += eventLen
+
+                    PhoenixBinaryMessage(null, null, topic, event, null, frame.copyOfRange(offset, frame.size))
+                }
+
+                else -> throw IllegalArgumentException("Unknown Phoenix binary frame kind: $kind")
+            }
+        }
+
         private fun jsonString(value: String?): JsonElement =
             if (value == null) JsonNull else JsonPrimitive(value)
 
         private fun stringOrNull(element: JsonElement): String? =
             if (element is JsonPrimitive && element != JsonNull) element.content else null
+
+        private fun write(source: ByteArray, target: ByteArray, offset: Int): Int {
+            source.copyInto(target, offset)
+            return offset + source.size
+        }
+
+        private fun unsigned(frame: ByteArray, index: Int): Int {
+            requireLength(frame, index + 1)
+            return frame[index].toInt() and 0xFF
+        }
+
+        private fun requireLength(frame: ByteArray, minimum: Int) {
+            require(frame.size >= minimum) {
+                "Truncated Phoenix binary frame: need at least $minimum bytes, got ${frame.size}"
+            }
+        }
+
+        private fun assertFieldSize(size: Int, name: String) {
+            require(size <= MAX_FIELD_BYTES) {
+                "unable to convert $name to binary: must be less than or equal to $MAX_FIELD_BYTES bytes, but is $size bytes"
+            }
+        }
     }
     """
   end
@@ -186,22 +375,39 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
 
   defp generate_push_class do
     """
-    // Push represents a message sent to the server awaiting a response
+    // Push represents a message sent to the server awaiting a response.
+    //
+    // A reply comes back as JSON or as binary independently of what was pushed:
+    // a server answering a binary push with a plain map replies in JSON. Hence
+    // two lanes, and await()/receive() keep their JSON signatures so every
+    // existing caller is untouched.
     class Push(
         val channel: PhoenixChannel,
         val event: String,
-        val payload: JsonElement,
+        val payload: ChannelPayload,
         private val timeout: Long = 10000L
     ) {
+        constructor(channel: PhoenixChannel, event: String, payload: JsonElement, timeout: Long = 10000L) :
+            this(channel, event, ChannelPayload.Json(payload), timeout)
+
+        constructor(channel: PhoenixChannel, event: String, payload: ByteArray, timeout: Long = 10000L) :
+            this(channel, event, ChannelPayload.Binary(payload), timeout)
+
         private var ref: String? = null
-        private var receivedResponse: JsonElement? = null
+        private var receivedResponse: ChannelPayload? = null
         private var status: PushStatus? = null
         private val responseCallbacks = mutableMapOf<String, (JsonElement) -> Unit>()
+        private val binaryResponseCallbacks = mutableMapOf<String, (ByteArray) -> Unit>()
         private var timeoutCallback: (() -> Unit)? = null
-        private val responded = kotlinx.coroutines.CompletableDeferred<Pair<PushStatus, JsonElement?>>()
+        private val responded = kotlinx.coroutines.CompletableDeferred<Pair<PushStatus, ChannelPayload?>>()
 
         fun receive(status: String, callback: (JsonElement) -> Unit): Push {
             responseCallbacks[status] = callback
+            return this
+        }
+
+        fun receiveBinary(status: String, callback: (ByteArray) -> Unit): Push {
+            binaryResponseCallbacks[status] = callback
             return this
         }
 
@@ -219,14 +425,11 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
         internal fun matchesRef(ref: String): Boolean = this.ref == ref
 
         internal fun trigger(status: String, response: JsonElement) {
-            this.status = when (status) {
-                "ok" -> PushStatus.OK
-                "error" -> PushStatus.ERROR
-                else -> PushStatus.ERROR
-            }
-            this.receivedResponse = response
-            responseCallbacks[status]?.invoke(response)
-            responded.complete(Pair(this.status!!, response))
+            complete(status, ChannelPayload.Json(response))
+        }
+
+        internal fun triggerBinary(status: String, response: ByteArray) {
+            complete(status, ChannelPayload.Binary(response))
         }
 
         internal fun triggerTimeout() {
@@ -235,13 +438,42 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             responded.complete(Pair(PushStatus.TIMEOUT, null))
         }
 
+        /** The reply, when the server sent JSON. Null for a binary reply. */
         suspend fun await(): Pair<PushStatus, JsonElement?> {
+            val (pushStatus, response) = awaitPayload()
+            return Pair(pushStatus, (response as? ChannelPayload.Json)?.element)
+        }
+
+        /** The reply, when the server sent binary. Null for a JSON reply. */
+        suspend fun awaitBinary(): Pair<PushStatus, ByteArray?> {
+            val (pushStatus, response) = awaitPayload()
+            return Pair(pushStatus, (response as? ChannelPayload.Binary)?.bytes)
+        }
+
+        /** The reply, whichever form it took. */
+        suspend fun awaitPayload(): Pair<PushStatus, ChannelPayload?> {
             return kotlinx.coroutines.withTimeoutOrNull(timeout) {
                 responded.await()
             } ?: run {
                 triggerTimeout()
                 Pair(PushStatus.TIMEOUT, null)
             }
+        }
+
+        private fun complete(status: String, response: ChannelPayload) {
+            this.status = when (status) {
+                "ok" -> PushStatus.OK
+                "error" -> PushStatus.ERROR
+                else -> PushStatus.ERROR
+            }
+            this.receivedResponse = response
+
+            when (response) {
+                is ChannelPayload.Json -> responseCallbacks[status]?.invoke(response.element)
+                is ChannelPayload.Binary -> binaryResponseCallbacks[status]?.invoke(response.bytes)
+            }
+
+            responded.complete(Pair(this.status!!, response))
         }
     }
     """
@@ -284,6 +516,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
         private var onCloseCallbacks = mutableListOf<(Int, String) -> Unit>()
         private var onErrorCallbacks = mutableListOf<(Throwable) -> Unit>()
         private var onMessageCallbacks = mutableListOf<(PhoenixMessage) -> Unit>()
+        private var onBinaryMessageCallbacks = mutableListOf<(PhoenixBinaryMessage) -> Unit>()
         private val scope = kotlinx.coroutines.CoroutineScope(kotlinx.coroutines.Dispatchers.IO + kotlinx.coroutines.SupervisorJob())
 
         fun generateRef(): String = (++refCounter).toString()
@@ -305,6 +538,11 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
 
         fun onMessage(callback: (PhoenixMessage) -> Unit): PhoenixSocket {
             onMessageCallbacks.add(callback)
+            return this
+        }
+
+        fun onBinaryMessage(callback: (PhoenixBinaryMessage) -> Unit): PhoenixSocket {
+            onBinaryMessageCallbacks.add(callback)
             return this
         }
 
@@ -351,6 +589,15 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
 
         internal suspend fun push(message: PhoenixMessage) {
             session?.send(io.ktor.websocket.Frame.Text(PhoenixSerializer.encodeText(message)))
+        }
+
+        internal suspend fun pushBinary(joinRef: String, ref: String, topic: String, event: String, payload: ByteArray) {
+            session?.send(
+                io.ktor.websocket.Frame.Binary(
+                    true,
+                    PhoenixSerializer.encodeBinaryPush(joinRef, ref, topic, event, payload)
+                )
+            )
         }
 
         internal fun registerPush(push: Push) {
@@ -403,6 +650,13 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
                                         onErrorCallbacks.forEach { it(e) }
                                     }
                                 }
+                                is io.ktor.websocket.Frame.Binary -> {
+                                    try {
+                                        handleBinaryMessage(PhoenixSerializer.decodeBinary(frame.data))
+                                    } catch (e: Exception) {
+                                        onErrorCallbacks.forEach { it(e) }
+                                    }
+                                }
                                 is io.ktor.websocket.Frame.Close -> {
                                     val reason = frame.readReason()
                                     disconnect(reason?.code?.toInt() ?: 1000, reason?.message ?: "Connection closed")
@@ -450,6 +704,23 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             channels[message.topic]?.handleMessage(message)
         }
 
+        private fun handleBinaryMessage(message: PhoenixBinaryMessage) {
+            onBinaryMessageCallbacks.forEach { it(message) }
+
+            // A binary reply resolves the push waiting on its ref. Its status
+            // is in the frame header, not in a JSON body, so there is nothing
+            // to parse out of the payload.
+            message.ref?.let { ref ->
+                pendingPushes[ref]?.let { push ->
+                    push.triggerBinary(message.status ?: "error", message.payload)
+                    pendingPushes.remove(ref)
+                    return
+                }
+            }
+
+            channels[message.topic]?.handleBinaryMessage(message)
+        }
+
         private fun scheduleReconnect() {
             if (reconnectAttempts >= maxReconnectAttempts) return
 
@@ -490,6 +761,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
         private var joinRef: String? = null
         private var joinPush: Push? = null
         private val bindings = mutableMapOf<String, MutableList<(JsonElement) -> Unit>>()
+        private val binaryBindings = mutableMapOf<String, MutableList<(ByteArray) -> Unit>>()
         private val pendingPushes = mutableListOf<Push>()
         private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
 
@@ -506,6 +778,19 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
 
         fun off(event: String): PhoenixChannel {
             bindings.remove(event)
+            return this
+        }
+
+        // Binary events bind separately so `on` keeps its JsonElement callback.
+        // A server can send either form under the same event name; bind both if
+        // yours does.
+        fun onBinary(event: String, callback: (ByteArray) -> Unit): PhoenixChannel {
+            binaryBindings.getOrPut(event) { mutableListOf() }.add(callback)
+            return this
+        }
+
+        fun offBinary(event: String): PhoenixChannel {
+            binaryBindings.remove(event)
             return this
         }
 
@@ -575,8 +860,43 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             return push
         }
 
+        /**
+         * Push raw bytes: a JPEG frame, an audio chunk, a file.
+         *
+         * The server sees `{:binary, data}` as the payload of `handle_in/3`, so
+         * nothing is base64-encoded and nothing is re-encoded to measure it. A
+         * reply arrives however the server sends it — `await()` for a JSON
+         * reply, `awaitBinary()` for a binary one.
+         *
+         * Requires a joined channel: Phoenix binds a binary push to the join
+         * ref, and a channel that has not joined has none.
+         */
+        suspend fun pushBinary(event: String, payload: ByteArray, timeout: Long = 10000L): Push {
+            if (state != ChannelState.JOINED) {
+                throw IllegalStateException("Cannot push on channel that is not joined")
+            }
+
+            val currentJoinRef = joinRef
+                ?: throw IllegalStateException("Cannot push binary on a channel with no join ref")
+
+            val push = Push(this, event, payload, timeout)
+            val ref = socket.generateRef()
+            push.setRef(ref)
+
+            socket.registerPush(push)
+            socket.pushBinary(currentJoinRef, ref, topic, event, payload)
+
+            return push
+        }
+
         internal fun handleMessage(message: PhoenixMessage) {
             bindings[message.event]?.forEach { callback ->
+                callback(message.payload)
+            }
+        }
+
+        internal fun handleBinaryMessage(message: PhoenixBinaryMessage) {
+            binaryBindings[message.event]?.forEach { callback ->
                 callback(message.payload)
             }
         }
@@ -754,6 +1074,41 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannel do
             return this
         }
 
+        /**
+         * Push raw bytes on the channel — an image frame, an audio chunk, a
+         * file — instead of base64 inside a JSON payload.
+         *
+         * The server receives `{:binary, data}` as the payload of `handle_in/3`.
+         * There is no RPC envelope around it: unlike [call], this sends the
+         * bytes and nothing else, so the event name is what tells the server
+         * what they are.
+         *
+         * @param event The event name the server matches in handle_in/3
+         * @param payload The bytes to send
+         * @param timeout Timeout in milliseconds
+         * @return the Push, to await a reply on
+         */
+        suspend fun pushBinary(event: String, payload: ByteArray, timeout: Long = 10000L): Push =
+            channel.pushBinary(event, payload, timeout)
+
+        /**
+         * Subscribe to binary events on the channel.
+         *
+         * Separate from [on], which delivers JSON. A server that sends both
+         * forms under one event name needs both bindings.
+         */
+        fun onBinary(event: String, callback: (ByteArray) -> Unit): AshRpcChannel {
+            channel.onBinary(event, callback)
+            return this
+        }
+
+        /**
+         * Unsubscribe from a binary event.
+         */
+        fun offBinary(event: String): AshRpcChannel {
+            channel.offBinary(event)
+            return this
+        }
     }
     """
   end

--- a/test/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel_test.exs
@@ -29,6 +29,22 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannelTest do
       refute result =~ "@SerialName(\"join_ref\")"
     end
 
+    test "generates PhoenixBinaryMessage for decoded incoming binary frames" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "class PhoenixBinaryMessage("
+      assert result =~ "val status: String?"
+      assert result =~ "val payload: ByteArray"
+    end
+
+    test "generates ChannelPayload so a push knows what it carried" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "sealed class ChannelPayload"
+      assert result =~ "data class Json(val element: JsonElement) : ChannelPayload()"
+      assert result =~ "class Binary(val bytes: ByteArray) : ChannelPayload()"
+    end
+
     test "generates ChannelState enum" do
       result = PhoenixChannel.generate()
 
@@ -141,6 +157,88 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannelTest do
       assert result =~ "jsonString(message.topic)"
       assert result =~ "jsonString(message.event)"
     end
+
+    test "writes the client push header as kind, join_ref, ref, topic, event" do
+      result = PhoenixChannel.generate()
+
+      assert result =~
+               "fun encodeBinaryPush(joinRef: String, ref: String, topic: String, event: String, payload: ByteArray): ByteArray"
+
+      assert result =~ "frame[0] = KIND_PUSH.toByte()"
+      assert result =~ "frame[1] = joinRefBytes.size.toByte()"
+      assert result =~ "frame[2] = refBytes.size.toByte()"
+      assert result =~ "frame[3] = topicBytes.size.toByte()"
+      assert result =~ "frame[4] = eventBytes.size.toByte()"
+    end
+
+    test "refuses a header field over the 255 bytes a length byte can hold" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "const val MAX_FIELD_BYTES = 255"
+      assert result =~ "private fun assertFieldSize(size: Int, name: String)"
+    end
+
+    test "decodes all three incoming kinds, each with its own header width" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "fun decodeBinary(frame: ByteArray): PhoenixBinaryMessage"
+      assert result =~ "const val KIND_PUSH = 0"
+      assert result =~ "const val KIND_REPLY = 1"
+      assert result =~ "const val KIND_BROADCAST = 2"
+    end
+  end
+
+  describe "pushing and receiving binary payloads" do
+    test "PhoenixChannel pushes a ByteArray without touching the JSON path" do
+      result = PhoenixChannel.generate()
+
+      assert result =~
+               "suspend fun pushBinary(event: String, payload: ByteArray, timeout: Long = 10000L): Push"
+
+      # The JSON push keeps its signature: it is every existing caller.
+      assert result =~
+               "suspend fun push(event: String, payload: JsonElement = JsonObject(emptyMap()), timeout: Long = 10000L): Push"
+    end
+
+    test "AshRpcChannel exposes the binary push and binary events" do
+      result = PhoenixChannel.generate()
+
+      assert result =~
+               "suspend fun pushBinary(event: String, payload: ByteArray, timeout: Long = 10000L): Push ="
+
+      assert result =~ "fun onBinary(event: String, callback: (ByteArray) -> Unit): AshRpcChannel"
+    end
+
+    test "PhoenixChannel binds binary events separately from JSON events" do
+      result = PhoenixChannel.generate()
+
+      assert result =~
+               "fun onBinary(event: String, callback: (ByteArray) -> Unit): PhoenixChannel"
+
+      assert result =~ "fun offBinary(event: String): PhoenixChannel"
+      # The JSON binding keeps its JsonElement callback.
+      assert result =~ "fun on(event: String, callback: (JsonElement) -> Unit): PhoenixChannel"
+    end
+
+    test "the socket reads incoming binary frames instead of dropping them" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "is io.ktor.websocket.Frame.Binary ->"
+      assert result =~ "PhoenixSerializer.decodeBinary("
+
+      assert result =~
+               "fun onBinaryMessage(callback: (PhoenixBinaryMessage) -> Unit): PhoenixSocket"
+    end
+
+    test "a Push can await a binary reply as well as a JSON one" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "suspend fun awaitBinary(): Pair<PushStatus, ByteArray?>"
+      assert result =~ "fun receiveBinary(status: String, callback: (ByteArray) -> Unit): Push"
+      # The JSON reply keeps its signature.
+      assert result =~ "suspend fun await(): Pair<PushStatus, JsonElement?>"
+      assert result =~ "fun receive(status: String, callback: (JsonElement) -> Unit): Push"
+    end
   end
 
   # These pin Phoenix's serializer, which lives in the phoenix package and can
@@ -151,6 +249,57 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannelTest do
   # lib/phoenix/socket/serializers/v2_json_serializer.ex.
   describe "the Phoenix v2 wire format the generated client is written against" do
     alias Phoenix.Socket.V2.JSONSerializer
+
+    @jpeg <<0xFF, 0xD8, 0xFF, 0xE0>>
+
+    test "a client-to-server push carries join_ref, ref, topic and event lengths" do
+      frame = <<0, 1, 1, 8, 5>> <> "7" <> "9" <> "camera:1" <> "frame" <> @jpeg
+
+      assert %Phoenix.Socket.Message{
+               join_ref: "7",
+               ref: "9",
+               topic: "camera:1",
+               event: "frame",
+               payload: {:binary, @jpeg}
+             } = JSONSerializer.decode!(frame, opcode: :binary)
+    end
+
+    test "a server-to-client push carries no ref, so its header is one byte shorter" do
+      {:socket_push, :binary, frame} =
+        JSONSerializer.encode!(%Phoenix.Socket.Message{
+          join_ref: "7",
+          ref: "9",
+          topic: "camera:1",
+          event: "frame",
+          payload: {:binary, @jpeg}
+        })
+
+      assert frame == <<0, 1, 8, 5>> <> "7" <> "camera:1" <> "frame" <> @jpeg
+    end
+
+    test "a reply puts the status where a push puts the event name" do
+      {:socket_push, :binary, frame} =
+        JSONSerializer.encode!(%Phoenix.Socket.Reply{
+          join_ref: "7",
+          ref: "9",
+          topic: "camera:1",
+          status: :ok,
+          payload: {:binary, @jpeg}
+        })
+
+      assert frame == <<1, 1, 1, 8, 2>> <> "7" <> "9" <> "camera:1" <> "ok" <> @jpeg
+    end
+
+    test "a broadcast carries neither join_ref nor ref" do
+      {:socket_push, :binary, frame} =
+        JSONSerializer.fastlane!(%Phoenix.Socket.Broadcast{
+          topic: "camera:1",
+          event: "frame",
+          payload: {:binary, @jpeg}
+        })
+
+      assert frame == <<2, 8, 5>> <> "camera:1" <> "frame" <> @jpeg
+    end
 
     test "a text frame is a five-element array, not the object v1 used" do
       {:socket_push, :text, iodata} =
@@ -164,6 +313,20 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannelTest do
 
       assert Phoenix.json_library().decode!(IO.iodata_to_binary(iodata)) ==
                ["7", "9", "rpc:lobby", "rpc", %{"action" => "list_todos"}]
+    end
+
+    test "a header field is capped at the 255 bytes its length byte can hold" do
+      oversized = String.duplicate("t", 256)
+
+      assert_raise ArgumentError, ~r/must be less than or equal to 255 bytes/, fn ->
+        JSONSerializer.encode!(%Phoenix.Socket.Message{
+          join_ref: "7",
+          ref: "9",
+          topic: oversized,
+          event: "frame",
+          payload: {:binary, @jpeg}
+        })
+      end
     end
   end
 end

--- a/test/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/codegen/phoenix_channel_test.exs
@@ -12,12 +12,21 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannelTest do
       result = PhoenixChannel.generate()
 
       assert result =~ "data class PhoenixMessage"
-      assert result =~ "@SerialName(\"join_ref\")"
       assert result =~ "val joinRef: String?"
       assert result =~ "val ref: String?"
       assert result =~ "val topic: String"
       assert result =~ "val event: String"
       assert result =~ "val payload: JsonElement"
+    end
+
+    test "PhoenixMessage is not @Serializable" do
+      # A v2 text frame is a JSON array. kotlinx.serialization would emit the
+      # data class as an object, which is the v1 shape, so the array is built
+      # by hand in PhoenixSerializer instead.
+      result = PhoenixChannel.generate()
+
+      refute result =~ "@Serializable\ndata class PhoenixMessage"
+      refute result =~ "@SerialName(\"join_ref\")"
     end
 
     test "generates ChannelState enum" do
@@ -111,6 +120,50 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.PhoenixChannelTest do
       assert result =~ "reconnectDelayMs"
       assert result =~ "maxReconnectAttempts"
       assert result =~ "scheduleReconnect()"
+    end
+  end
+
+  describe "the generated PhoenixSerializer" do
+    test "negotiates v2, which is the only version with a binary frame" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "const val VSN = \"2.0.0\""
+      assert result =~ ~s|("vsn" to PhoenixSerializer.VSN)|
+    end
+
+    test "encodes a text frame as the five-element array v2 expects" do
+      result = PhoenixChannel.generate()
+
+      assert result =~ "fun encodeText(message: PhoenixMessage): String"
+      assert result =~ "fun decodeText(text: String): PhoenixMessage"
+      assert result =~ "jsonString(message.joinRef)"
+      assert result =~ "jsonString(message.ref)"
+      assert result =~ "jsonString(message.topic)"
+      assert result =~ "jsonString(message.event)"
+    end
+  end
+
+  # These pin Phoenix's serializer, which lives in the phoenix package and can
+  # change without anything in this repository noticing. Each builds or reads
+  # the exact byte layout the generated PhoenixSerializer is written against,
+  # so a Phoenix change to the format fails here rather than silently producing
+  # frames the server drops. Verified against Phoenix 1.8.13,
+  # lib/phoenix/socket/serializers/v2_json_serializer.ex.
+  describe "the Phoenix v2 wire format the generated client is written against" do
+    alias Phoenix.Socket.V2.JSONSerializer
+
+    test "a text frame is a five-element array, not the object v1 used" do
+      {:socket_push, :text, iodata} =
+        JSONSerializer.encode!(%Phoenix.Socket.Message{
+          join_ref: "7",
+          ref: "9",
+          topic: "rpc:lobby",
+          event: "rpc",
+          payload: %{"action" => "list_todos"}
+        })
+
+      assert Phoenix.json_library().decode!(IO.iodata_to_binary(iodata)) ==
+               ["7", "9", "rpc:lobby", "rpc", %{"action" => "list_todos"}]
     end
   end
 end


### PR DESCRIPTION
Closes #49.

The generated Phoenix channel client could not send bytes. `pushBinary` now
does, and incoming binary frames — which the socket had been dropping —
now decode and route.

Getting there needed a fix first: **the client was speaking v1, not v2**. Its
docstring claimed v2, but the socket sent no `vsn` query parameter, and
Phoenix defaults an absent `vsn` to `"1.0.0"`
(`deps/phoenix/lib/phoenix/socket.ex`, `__connect__/3`), which
`deps/phoenix/lib/phoenix/transports/websocket.ex:29` matches to
`Phoenix.Socket.V1.JSONSerializer`. The `@Serializable PhoenixMessage`
encoded to the JSON object v1 wants, so it worked — silently, as a v1
client. v1's `decode!/2` JSON-decodes whatever arrives and has no binary
branch at all, so no binary frame could reach a channel until the socket
negotiated v2.

Three commits, plus the source of truth the issue asked for.

## The shape: a separate `pushBinary`, not a widened payload type

The JSON path is every existing user of this library, so none of its
signatures move.

```kotlin
channel.push("rpc", jsonPayload)          // unchanged
channel.pushBinary("frame", jpegBytes)    // new
```

Widening `push`'s parameter to a sealed type would have made the common call
read `push(event, ChannelPayload.Json(x))` — a worse API for everyone, to
serve the rarer case.

`Push` grows a second lane for the same reason. A server answering a binary
push with a plain map replies in **JSON**, so `await()` and `receive()` keep
their `JsonElement` signatures; `awaitBinary()` and `receiveBinary()` are
there for a server that replies `{:binary, data}`, and `awaitPayload()` is
the one that never hides a reply. `Push.payload` becomes a `ChannelPayload`
so it stops claiming a binary push carried JSON; its `JsonElement`
constructor is kept, so no call site changes.

Receiving binds separately too: `channel.onBinary(event) { bytes -> }`, so
`on` keeps its `JsonElement` callback. A binary reply resolves the push
waiting on its ref, taking its status from the frame header.

## The wire format, and how it was checked

Read from `deps/phoenix/lib/phoenix/socket/serializers/v2_json_serializer.ex`
and `deps/phoenix/assets/js/phoenix/serializer.js` in a real Phoenix 1.8.13
checkout, not from memory.

Text frames are the JSON array `[join_ref, ref, topic, event, payload]`, not
an object. A `@Serializable` data class can only emit the object, which is
why `PhoenixMessage` lost the annotation and is encoded by hand.

Binary frames are length-prefixed, one unsigned byte per field, and **the
layouts are not symmetric**:

| Direction | Kind | Header bytes | Fields after the header |
| --------- | ---- | ------------ | ----------------------- |
| Client to server | `0` push | `0`, joinRefLen, refLen, topicLen, eventLen | joinRef, ref, topic, event, data |
| Server to client | `0` push | `0`, joinRefLen, topicLen, eventLen | joinRef, topic, event, data (no ref) |
| Server to client | `1` reply | `1`, joinRefLen, refLen, topicLen, statusLen | joinRef, ref, topic, status, data |
| Server to client | `2` broadcast | `2`, topicLen, eventLen | topic, event, data (no refs) |

The outgoing push carries a ref and the incoming one does not; a reply puts
its status where a push puts its event name. Reuse one layout for both
directions and you misread every field, with no error on either side — the
server just drops the frame.

Verified three ways, not one:

**1. Against Phoenix's own serializer, in the test suite.** A new `describe`
block builds or reads each layout through `Phoenix.Socket.V2.JSONSerializer`
itself, including the 255-byte field cap. That format lives in another
package, so nothing here would otherwise notice it changing. It names the
Phoenix version it was checked on.

**2. The emitted Kotlin compiles.** The gate PR #52 made blocking, run on
this branch:

```
$ MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture   # exit 0
$ cd test/fixtures/kotlin_compile && gradle compileKotlin --console=plain
BUILD SUCCESSFUL in 3s                                           # exit 0
```

Zero errors. The only output is the two pre-existing "Redundant creation of
Json format" warnings from `RpcResult.dataAs()`, one per subproject,
unchanged from `main`.

**3. The bytes the compiled Kotlin actually produces decode in Phoenix.**
The stronger check, because a compiler cannot tell you the header order is
wrong. A scratch JVM project built from the generated `AshRpc.kt` (not
committed) printed what `PhoenixSerializer` emits:

```
PUSH 0001010805373963616d6572613a316672616d65ffd8ffe0
TEXT ["7","9","rpc:lobby","rpc",{"action":"list_todos"}]
HEARTBEAT [null,"3","phoenix","heartbeat",{}]
```

Fed straight into the real serializer:

```elixir
Phoenix.Socket.V2.JSONSerializer.decode!(push_bytes, opcode: :binary)
#=> %Phoenix.Socket.Message{
#     topic: "camera:1", event: "frame",
#     payload: {:binary, <<255, 216, 255, 224>>}, ref: "9", join_ref: "7"}
```

The same project decoded all three server-to-client kinds correctly:

```
SERVER_PUSH joinRef=7 ref=null   topic=camera:1 event=frame     status=null payload=ffd8ffe0
REPLY       joinRef=7 ref=9      topic=camera:1 event=phx_reply  status=ok   payload=ffd8ffe0
BROADCAST   joinRef=null ref=null topic=camera:1 event=frame     status=null payload=ffd8ffe0
```

## Breaking changes

Both are in the CHANGELOG.

- **On the wire.** A regenerated client sends `vsn=2.0.0`. The stock Phoenix
  socket offers v1 and v2 and needs no change; a host that narrowed its
  `serializer:` option to v1 only must add v2.
- **On the Kotlin API.** `PhoenixMessage` is no longer `@Serializable` and
  `joinRef` no longer carries `@SerialName("join_ref")`; encode and decode
  through `PhoenixSerializer`. `Push.payload` is a `ChannelPayload`.

## Source of truth

The issue asked for it, and the repository had neither `CLAUDE.md` nor
`docs/`. The first commit creates them, drawn from the code rather than the
README: `docs/PROJECT.md` as the hub, plus `architecture.md` (C4 as Mermaid,
naming the real modules), `decisions.md`, `risks.md` and `roadmap.md`. The
last commit updates them for this change, so they describe `main` as it will
be on merge.

`CLAUDE.md` carries only what is true of this repository — how to run the
compile gate, that `mix format` fails on ten files that predate the current
rules (#38), and the two wire-format traps above.

## Test plan

Real exit codes, on `a2be9b8` off `a975749`.

| Command | Exit | Result |
| ------- | ---- | ------ |
| `mix compile --force --warnings-as-errors` | 0 | clean |
| `mix test` | 0 | 150 tests, 0 failures (122 on `main`) |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` | 0 | both subprojects written |
| `gradle compileKotlin` in `test/fixtures/kotlin_compile` | 0 | BUILD SUCCESSFUL, 0 errors |
| `mix format --check-formatted` | 1 | **pre-existing (#38)** |

The format check fails on `main` too, on exactly the same ten files —
`typed_queries.ex`, `phoenix/controller.ex`, `verify_unique_type_names.ex`,
`rpc/codegen.ex`, `payload_builder.ex`, `metadata_types.ex`,
`swift/codegen.ex`, `swift/type_mapper_test.exs`, `test/support/resources/user.ex`,
`test/support/test_domain.ex`. None are touched here and the list is
unchanged; every file this PR edits is formatter-clean.

## What is not covered

The generated Kotlin is compiled, and the bytes it produces are decoded by
Phoenix, but nothing in CI runs a Kotlin client against a live Phoenix
socket. The `Push` reply lanes, the reconnect path and `onBinary` routing are
asserted as emitted source, not exercised at runtime. That gap is the whole
of `risks.md`'s first entry and predates this PR.
