### PR TITLE
fix: the generated Kotlin client can decode the server's own responses

### DIFF
--- a/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/resource_schemas.ex
@@ -189,23 +189,17 @@ defmodule AshKotlinMultiplatform.Codegen.ResourceSchemas do
     # If server outputs snake_case, we need @SerialName for the snake_case JSON key
     serial_name = get_serial_name_annotation(original_name, field_name)
 
-    # All fields except `id` get defaults since RPC uses sparse fieldsets
-    # This allows responses to omit fields that weren't requested
+    # Every field is nullable with a default, `id` included. RPC uses sparse
+    # fieldsets, so any field the request did not ask for is absent from the
+    # response, and a field with no default is a `MissingFieldException` at
+    # decode time. `id` used to be exempt on the theory that it is "always
+    # present" — `fields = ["title"]` omits it like any other, and that threw on
+    # every sparse read that left it out (#24).
     {kotlin_type, default} =
-      cond do
-        # ID field is always required and present
-        attribute.name == :id ->
-          {kotlin_type, ""}
-
-        # Nullable fields get null default
-        attribute.allow_nil? ->
-          {kotlin_type, " = null"}
-
-        # Non-nullable fields need to be made nullable with defaults for sparse responses
-        true ->
-          nullable_type = make_nullable(kotlin_type)
-          default_value = get_default_for_type(kotlin_type)
-          {nullable_type, " = #{default_value}"}
+      if attribute.allow_nil? do
+        {kotlin_type, " = null"}
+      else
+        {make_nullable(kotlin_type), " = #{get_default_for_type(kotlin_type)}"}
       end
 
     "#{serial_name}val #{field_name}: #{TypeMapper.annotate_contextual_types(kotlin_type)}#{default}"

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -236,22 +236,47 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   @doc """
   Generates the validation result type.
   """
+  # A plain `@Serializable sealed class` makes kotlinx-serialization look for a
+  # `"type"` class discriminator. `Rpc.Runner.build_validation_success_response/0`
+  # sends `{"success":true,"valid":true}` and
+  # `build_validation_error_response/1` sends the same with `"valid":false` and
+  # an `"errors"` list — neither carries a discriminator, so every `validateX()`
+  # call threw `JsonDecodingException` on decode (#24).
+  #
+  # `valid` is the discriminator the server already sends, and
+  # `JsonContentPolymorphicSerializer` is how kotlinx reads one out of the
+  # content rather than out of a synthetic key:
+  # https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/
+  # Choosing it over adding `"type"` to the response keeps the wire format the
+  # Swift generator and the Phoenix channel client already read unchanged.
   def generate_validation_types do
     """
     // Validation result types
-    @Serializable
+    @Serializable(with = ValidationResultSerializer::class)
     sealed class ValidationResult {
         abstract val valid: Boolean
     }
 
+    // The server sends no class discriminator, so the `valid` flag is the
+    // discriminator. See AshKotlinMultiplatform.Rpc.Runner.
+    object ValidationResultSerializer :
+        JsonContentPolymorphicSerializer<ValidationResult>(ValidationResult::class) {
+        override fun selectDeserializer(
+            element: JsonElement
+        ): DeserializationStrategy<ValidationResult> =
+            if (element.jsonObject["valid"]?.jsonPrimitive?.booleanOrNull == true) {
+                ValidationValid.serializer()
+            } else {
+                ValidationInvalid.serializer()
+            }
+    }
+
     @Serializable
-    @SerialName("valid")
     data class ValidationValid(
         override val valid: Boolean = true
     ) : ValidationResult()
 
     @Serializable
-    @SerialName("invalid")
     data class ValidationInvalid(
         override val valid: Boolean = false,
         val errors: List<AshRpcError>

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -213,6 +213,12 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   @doc """
   Generates the generic RPC result types.
   """
+  # No `metadata` property. `Rpc.Runner.build_success_response/1` returns
+  # `success` and `data` and nothing else, and action metadata reaches the
+  # client *inside* `data` — `AshIntrospection.Rpc.Pipeline.add_metadata/4`
+  # merges the exposed fields into the record. A top-level `metadata` promised a
+  # key the server has never sent, so it decoded as `null` every time and sent
+  # readers looking for it in the wrong place (#24).
   def generate_generic_result_types do
     """
     // Generic result wrapper
@@ -220,8 +226,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
     data class RpcResult(
         val success: Boolean,
         val data: JsonElement? = null,
-        val errors: List<AshRpcError>? = null,
-        val metadata: JsonElement? = null
+        val errors: List<AshRpcError>? = null
     ) {
         inline fun <reified T> dataAs(): T? {
             return data?.let { Json { ignoreUnknownKeys = true }.decodeFromJsonElement<T>(it) }

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -188,6 +188,12 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   @doc """
   Generates the RPC error types.
   """
+  # `shortMessage` carries no `@SerialName`. Every error map `Rpc.Runner` builds
+  # writes the key `"shortMessage"` literally, under every
+  # `output_field_formatter` setting: see `build_error_response/1`,
+  # `format_validation_errors/1` and `format_single_error/1`. Annotating the
+  # field `short_message` therefore made it decode as `null` on every error the
+  # server has ever sent (#24).
   def generate_error_types do
     """
     // RPC Error types
@@ -195,7 +201,6 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
     data class AshRpcError(
         val type: String? = null,
         val message: String? = null,
-        @SerialName("short_message")
         val shortMessage: String? = null,
         val vars: Map<String, String> = emptyMap(),
         val fields: List<String> = emptyList(),

--- a/test/ash_kotlin_multiplatform/rpc/client_server_contract_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/client_server_contract_test.exs
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.ClientServerContractTest do
+  @moduledoc """
+  The Kotlin this library emits must decode what this library's own server sends.
+
+  Issue #24 found four places where it could not, and every one of them survived
+  because both halves looked right on their own. So each test here pairs a real
+  response from `Runner` with the declaration the generator emits to decode it:
+  changing either side alone fails the pair.
+
+  These assertions are the cheap half. The expensive half is
+  `tmp/roundtrip` in the PR that closed #24, which hands the same responses to
+  a real `kotlinx-serialization` decoder — the only thing that proves a
+  declaration decodes rather than merely reads correctly.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic
+  alias AshKotlinMultiplatform.Rpc.Runner
+  alias AshKotlinMultiplatform.Test.Author
+
+  defp run(params), do: Runner.run_action(:ash_kotlin_multiplatform, params)
+  defp validate(params), do: Runner.validate_action(:ash_kotlin_multiplatform, params)
+
+  defp create_author(name) do
+    assert %{"success" => true, "data" => author} =
+             run(%{
+               "action" => "create_author",
+               "input" => %{"name" => name, "email" => "#{name}@example.com"},
+               "fields" => ["id"]
+             })
+
+    author["id"]
+  end
+
+  describe "AshRpcError.shortMessage" do
+    test "the key the server sends is the key the generated class reads" do
+      assert %{"success" => false, "errors" => [error]} = run(%{"action" => "no_such_action"})
+      assert error["shortMessage"] == "Action not found"
+
+      kotlin = KotlinStatic.generate_error_types()
+
+      assert kotlin =~ "val shortMessage: String? = null"
+      refute kotlin =~ "@SerialName(\"short_message\")"
+    end
+
+    test "a field-selection error uses the same key" do
+      assert %{"success" => false, "errors" => [error]} =
+               run(%{"action" => "list_authors", "fields" => ["nope"]})
+
+      assert error["shortMessage"] == "Unknown field"
+    end
+  end
+
+  describe "ValidationResult" do
+    test "the server sends no class discriminator, so the sealed class must not need one" do
+      assert validate(%{"action" => "create_todo", "input" => %{"title" => "Ship it"}}) ==
+               %{"success" => true, "valid" => true}
+
+      kotlin = KotlinStatic.generate_validation_types()
+
+      assert kotlin =~ "@Serializable(with = ValidationResultSerializer::class)"
+      assert kotlin =~ "JsonContentPolymorphicSerializer<ValidationResult>"
+      refute kotlin =~ "@SerialName(\"valid\")"
+      refute kotlin =~ "@SerialName(\"invalid\")"
+    end
+
+    test "an invalid changeset is discriminated by the same valid flag" do
+      assert %{"success" => true, "valid" => false, "errors" => [error]} =
+               validate(%{"action" => "create_todo", "input" => %{}})
+
+      assert error["field"] == "title"
+    end
+  end
+
+  describe "sparse fieldsets" do
+    test "id is omitted when it was not asked for, so its Kotlin field needs a default" do
+      create_author("Ursula Le Guin")
+
+      assert %{"success" => true, "data" => [author]} =
+               run(%{"action" => "list_authors", "fields" => ["name"]})
+
+      refute Map.has_key?(author, "id")
+
+      assert ResourceSchemas.generate_data_class(Author, [Author]) =~ "val id: String? = null"
+    end
+  end
+
+  describe "RpcResult" do
+    test "declares no field for a key the server never sends" do
+      create_author("Octavia Butler")
+
+      assert %{"success" => true, "data" => _} = response = run(%{"action" => "list_authors"})
+      assert Map.keys(response) |> Enum.sort() == ["data", "success"]
+
+      refute KotlinStatic.generate_generic_result_types() =~ "val metadata"
+    end
+
+    test "action metadata arrives inside data, not beside it" do
+      response =
+        run(%{
+          "action" => "register_event",
+          "input" => %{"name" => "Launch"},
+          "metadataFields" => ["registeredAt"]
+        })
+
+      assert %{"success" => true, "data" => data} = response
+      refute Map.has_key?(response, "metadata")
+      assert data["metadata"] == %{"registeredAt" => ~U[2026-01-01 00:00:00Z]}
+    end
+  end
+end


### PR DESCRIPTION
Four places where this library's generated Kotlin client could not decode this
library's own Elixir server. Every one of them was invisible to the compile
gate, because every one of them compiles.

Closes #24. **#48 is not in this PR** — see the last section.

## What was broken, and the proof

Each defect was reproduced by handing a real `Rpc.Runner` response to a real
`kotlinx-serialization` decoder built from the generated `AshRpc.kt`. Same
harness, same responses, before and after.

| # | Defect | Before | After |
| --- | --- | --- | --- |
| 1 | `AshRpcError` declared `@SerialName("short_message")`; the server sends `"shortMessage"` | `shortMessage = null` on every error | `shortMessage = Action not found` |
| 2 | `ValidationResult` was a sealed class needing a `"type"` discriminator; the server sends `{"success":true,"valid":true}` | `JsonDecodingException: Class discriminator was missing` on **every** `validateX()` call | `valid = true (ValidationValid)` / `valid = false, errors = 1` |
| 3 | `id` was the one field generated without a default; a sparse fieldset omits it | `MissingFieldException: Field 'id' is required` | decodes, `id = null` |
| 4 | `RpcResult.metadata` decoded a key the server never emits | server sends `[data, success]`; property always `null` | `RpcResult declares [success, data, errors]` |

Full harness output, kotlinx-datetime variant, kotlinx-serialization 1.11.0,
Kotlin 2.4.20, JDK 21:

```
FAIL defect1 shortMessage populated -> shortMessage = null (server sent "Action not found")
FAIL defect1 shortMessage populated (invalid fields) -> shortMessage = null
FAIL defect2 validation success decodes -> JsonDecodingException: Class discriminator was missing and no default serializers were registered in the polymorphic scope of 'ValidationResult'.
FAIL defect2 validation failure decodes -> JsonDecodingException: Class discriminator was missing and no default serializers were registered in the polymorphic scope of 'ValidationResult'.
FAIL defect3 sparse fieldset decodes -> MissingFieldException: Field 'id' is required for type with serial name 'com.ashkotlinmultiplatform.ash.Author', but it was missing
OK   defect3 control: full fieldset decodes -> authors = [8587fc6d-.../Ursula Le Guin]
INFO defect4 -> server sent keys [data, success]; RpcResult.metadata = null
OK   sanity enum field decodes -> Status.IN_PROGRESS
5 FAILURE(S)
```

```
OK   defect1 shortMessage populated -> shortMessage = Action not found (server sent "Action not found")
OK   defect1 shortMessage populated (invalid fields) -> shortMessage = Unknown field
OK   defect2 validation success decodes -> valid = true (ValidationValid)
OK   defect2 validation failure decodes -> valid = false, errors = 1 first shortMessage = Validation failed
OK   defect3 sparse fieldset decodes -> authors = [null/Ursula Le Guin]
OK   defect3 control: full fieldset decodes -> authors = [8587fc6d-.../Ursula Le Guin]
OK   defect4 RpcResult declares no key the server never sends -> server sent keys [data, success]; RpcResult declares [success, data, errors]
OK   sanity enum field decodes -> Status.IN_PROGRESS
ALL PASS
```

## The changes

**1. `AshRpcError.shortMessage` loses its `@SerialName`.** Every error map
`Rpc.Runner` builds writes the key `"shortMessage"` literally, under every
`output_field_formatter` setting — `build_error_response/1`,
`format_validation_errors/1` and `format_single_error/1` all do. Annotating the
field `short_message` therefore made it null on every error the server has ever
sent. Removing the annotation makes the two agree under every configuration. That the
server ignores `output_field_formatter` for error keys at all is filed
separately as #57.

**2. `ValidationResult` reads its discriminator out of the content.** `valid` is
the discriminator the server already sends, so a
[`JsonContentPolymorphicSerializer`](https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-json/kotlinx.serialization.json/-json-content-polymorphic-serializer/)
selects the subclass from it. Chosen over adding a `"type"` key to the response
because that would change a wire format the Swift generator and the Phoenix
channel client already read. The `@SerialName("valid")`/`@SerialName("invalid")`
annotations go: with a content-based discriminator they name nothing.

**3. `id` gets a default like every other field.** It was exempt on the theory
that it is always present. A sparse fieldset omits it like any other:
`fields = ["title"]` returns `{"title": ...}` and `dataAs<Todo>()` threw. This
deletes the special case rather than adding one.

**4. `RpcResult` drops `metadata`.** `build_success_response/1` returns `success`
and `data` and nothing else. Action metadata reaches the client **inside**
`data` — `AshIntrospection.Rpc.Pipeline.add_metadata/4` merges the exposed
fields into the record. The top-level property decoded as null every time and
pointed readers at the wrong place.

## Note for the #44/#45 branch

Defect 3 touches `resource_schemas.ex`, which #52 also changed. The change is
confined to `generate_field/1` and is a deletion: the `attribute.name == :id`
branch of a three-way `cond` goes, leaving the remaining two as an `if`. It does
not touch `generate_data_class/2` or its new signature.

## Test plan

- `mix test` — **138 tests, 0 failures** (was 131 on `main`; this adds 7).
- `mix compile --warnings-as-errors` — clean.
- `MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` then
  `gradle compileKotlin` in `test/fixtures/kotlin_compile` — **BUILD SUCCESSFUL**
  on both the `kotlinx-datetime` and `java-time` subprojects, locally on Gradle
  9.7.0 / JDK 21. One pre-existing warning about the inline `Json` in `dataAs`.
- The decode round trip above, run by hand. It is not in CI: wiring a runtime
  Kotlin gate needs a `.github/workflows/ci.yml` change, and that file belongs to
  the #44/#45 branch. Worth a follow-up — the compile gate cannot see any of
  these four defects.

`test/ash_kotlin_multiplatform/rpc/client_server_contract_test.exs` is the
committed half: each test pairs a real `Runner` response with the declaration
the generator emits to decode it, so changing either side alone fails the pair.

## #48 is blocked upstream, on two counts

I implemented the one-line switch from `Pipeline.format_output/1` to
`format_output_with_request/3` and measured it. It is not shippable:

1. **udin-io/ash_introspection#57**, exactly as predicted there. **14 of 138**
   tests fail. An unpaginated multi-record read comes back with internal atom
   keys: `%{"data" => [%{id: "160b3543-...", name: "KSR"}]}`. `format_resource/4`
   only matches a map, so the list falls through unformatted.

2. **udin-io/ash_introspection#62**, which I filed. It is new, and it means the
   switch would not have fixed #48 even with #57 resolved.
   `unconstrained_map_action?/1` requires `action.constraints == []`, but `ash`
   3.33.1 fills `Ash.Type.Map`'s defaults, so the constraints are
   `[preserve_nil_values?: false]` and the guard never matches. The untyped map
   is destroyed in stage 3 (`process_result/3`), before any formatting runs:

   ```
   returned by the action: %{"_id" => "author-1", "field_1_name" => "kept", "nested" => %{"_rev" => "2"}}
   reaching the client:    %{"id" => nil, "name" => nil, "email" => nil}
   ```

   The payload is gone, not re-keyed, and replaced by three nil fields the action
   never produced.

Both belong upstream. Compensating for a core bug in the consumer is how the two
drift apart, so #48 stays open until #57 and #62 land.
