### PR TITLE
Compile-time verifiers: non-public actions, field?: false calculations, union member names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Union member names that Kotlin cannot compile are now caught at compile
+  time. A union attribute is the one place where a name inside
+  `constraints` becomes a Kotlin identifier: the sealed class turns each
+  member name into a subclass name and each field of a map member into a
+  property, so a member `is_valid?` emitted `data class IsValid?(` and a
+  member field `ok?` emitted `val ok?:`. Both are rejected now, with the
+  attribute, the member and a suggested name in the message. **Breaking
+  for existing users** whose union members carry such names — but their
+  generated Kotlin did not compile either. Names the generator erases (a
+  `:map` attribute's fields, a `:tuple`'s) are deliberately not checked.
+
 - A calculation declared `field?: false` no longer reaches the generated
   Kotlin. Ash keeps such a calculation's value in the record's
   `calculations` map instead of as a struct key, so the generator had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Breaking for existing users.** Compile-time check that every action
+  reachable from the generated Kotlin client is `public?`. Ash documents
+  `public? false` as "internal-only and must not be exposed by API
+  extensions"; nothing enforced that here, so a `rpc_action` naming a
+  non-public action produced a fully typed client function for it. Four
+  places are checked: the action a `rpc_action` names, the `read_action` a
+  `rpc_action` uses to find records, the action a `typed_query` names, and
+  the read action behind a public relationship whose destination is itself
+  a Kotlin resource. A project that was exposing a non-public action now
+  fails to compile; the error names the offending action and says whether
+  to mark it `public? true` or drop the entry.
+
 - Binary payloads on the generated Phoenix channel client.
   `PhoenixChannel.pushBinary/3` and `AshRpcChannel.pushBinary/3` send a
   `ByteArray` as a Phoenix binary frame, which the server receives as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously dropped by the socket's receive loop. The JSON path is
   unchanged: `push`, `on`, `receive` and `await` keep their signatures.
 
+### Fixed
+
+- A calculation declared `field?: false` no longer reaches the generated
+  Kotlin. Ash keeps such a calculation's value in the record's
+  `calculations` map instead of as a struct key, so the generator had
+  nowhere to read it from, yet it still appeared in the data class, the
+  filter input, type discovery and field-name verification. The last of
+  those could fail a build outright: a `field?: false` calculation named
+  `score_1` was rejected for a name that never reached Kotlin.
+
 ### Changed
 
 - **Breaking on the wire.** The generated channel client now speaks

--- a/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/filter_types.ex
@@ -270,8 +270,7 @@ defmodule AshKotlinMultiplatform.Codegen.FilterTypes do
       |> Ash.Resource.Info.public_attributes()
 
     calcs =
-      resource
-      |> Ash.Resource.Info.public_calculations()
+      AshKotlinMultiplatform.Resource.Info.public_field_calculations(resource)
 
     (attrs ++ calcs)
     |> Enum.map(&generate_attribute_filter(&1, resource))

--- a/lib/ash_kotlin_multiplatform/codegen/type_discovery.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_discovery.ex
@@ -419,7 +419,7 @@ defmodule AshKotlinMultiplatform.Codegen.TypeDiscovery do
 
   defp get_public_calculations(resource) do
     try do
-      Ash.Resource.Info.public_calculations(resource)
+      AshKotlinMultiplatform.Resource.Info.public_field_calculations(resource)
     rescue
       _ -> []
     end

--- a/lib/ash_kotlin_multiplatform/resource.ex
+++ b/lib/ash_kotlin_multiplatform/resource.ex
@@ -53,6 +53,7 @@ defmodule AshKotlinMultiplatform.Resource do
     sections: [@kotlin_multiplatform],
     verifiers: [
       AshKotlinMultiplatform.Resource.Verifiers.VerifyFieldNames,
+      AshKotlinMultiplatform.Resource.Verifiers.VerifyUnionMemberNames,
       AshKotlinMultiplatform.Resource.Verifiers.VerifyUniqueTypeNames
     ]
 end

--- a/lib/ash_kotlin_multiplatform/resource/info.ex
+++ b/lib/ash_kotlin_multiplatform/resource/info.ex
@@ -99,6 +99,28 @@ defmodule AshKotlinMultiplatform.Resource.Info do
   end
 
   @doc """
+  Returns the resource's public calculations that are fields on the struct.
+
+  Ash stores a calculation declared `field?: false` in the record's
+  `calculations` map rather than as a struct key, so the generator has nowhere
+  to put it: it is absent from the Kotlin data class, from the filter input and
+  from anything that reads a field off a record. Every call site that treats a
+  calculation as a generatable field goes through here.
+  """
+  def public_field_calculations(resource) do
+    resource
+    |> Ash.Resource.Info.public_calculations()
+    |> Enum.filter(&field_calculation?/1)
+  end
+
+  @doc """
+  Whether a calculation is a field on the resource struct.
+
+  Defaults to `true`, matching Ash's own default for the `field?` option.
+  """
+  def field_calculation?(calculation), do: Map.get(calculation, :field?, true)
+
+  @doc """
   Gets the mapped field name for a given field.
 
   Returns the mapped name if a mapping exists, otherwise returns the original field name.

--- a/lib/ash_kotlin_multiplatform/resource/verifiers/verify_field_names.ex
+++ b/lib/ash_kotlin_multiplatform/resource/verifiers/verify_field_names.ex
@@ -66,7 +66,7 @@ defmodule AshKotlinMultiplatform.Resource.Verifiers.VerifyFieldNames do
     # Check public calculations
     invalid_fields =
       invalid_fields ++
-        (Ash.Resource.Info.public_calculations(resource)
+        (AshKotlinMultiplatform.Resource.Info.public_field_calculations(resource)
          |> Enum.filter(fn calc ->
            mapped_name =
              AshKotlinMultiplatform.Resource.Info.get_mapped_field_name(resource, calc.name)

--- a/lib/ash_kotlin_multiplatform/resource/verifiers/verify_union_member_names.ex
+++ b/lib/ash_kotlin_multiplatform/resource/verifiers/verify_union_member_names.ex
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Resource.Verifiers.VerifyUnionMemberNames do
+  @moduledoc """
+  Rejects union member names that Kotlin cannot compile.
+
+  A union attribute is the one place in this generator where a name written
+  inside `constraints` becomes a Kotlin identifier.
+  `AshKotlinMultiplatform.Codegen.ResourceSchemas.generate_sealed_class/1` turns
+  each member name into a subclass name and each field of a map member into a
+  property, so a member named `is_valid?` emitted `data class IsValid?(` and a
+  member field named `ok?` emitted `val ok?:` — output the Kotlin compile gate
+  refuses. Nothing caught it, because the resource verifiers only ever looked at
+  top-level field names.
+
+  Deliberately narrow. Every other constraint name this generator meets is
+  erased before it reaches Kotlin: a `:map` attribute becomes an untyped map, a
+  `:tuple` a `List`, a union outside a resource attribute a `@Contextual Any`.
+  Their field names never appear in the output, so rejecting them would fail
+  builds over names that cause no harm. Only what `ResourceSchemas` actually
+  emits is checked here — a public attribute whose type is `Ash.Type.Union`,
+  which is the sole shape `collect_types/1` generates a sealed class for.
+
+  There is no escape hatch by design: `interop_field_names/0` and the
+  `field_names` DSL option are not consulted when emitting a sealed class, so a
+  mapping would not change the generated name. Rename the member.
+  """
+  use Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl) do
+    resource = dsl[:persist][:module]
+
+    resource
+    |> Ash.Resource.Info.public_attributes()
+    |> Enum.flat_map(&validate_attribute(resource, &1))
+    |> case do
+      [] -> :ok
+      errors -> format_errors(resource, errors)
+    end
+  end
+
+  defp validate_attribute(_resource, %{type: Ash.Type.Union} = attribute) do
+    attribute.constraints
+    |> Kernel.||([])
+    |> Keyword.get(:types, [])
+    |> Enum.flat_map(&validate_member(attribute.name, &1))
+  end
+
+  defp validate_attribute(_resource, _attribute), do: []
+
+  defp validate_member(attribute_name, {member_name, member_config}) do
+    name_errors =
+      if invalid_name?(member_name) do
+        [{attribute_name, :union_member, member_name, better_name(member_name)}]
+      else
+        []
+      end
+
+    name_errors ++ validate_member_fields(attribute_name, member_name, member_config)
+  end
+
+  # Only a member whose type is literally `Ash.Type.Map` with `fields` gets its
+  # field names emitted; every other member type reaches Kotlin as a single
+  # `value` property, so its constraint names are erased.
+  defp validate_member_fields(attribute_name, member_name, member_config) do
+    with Ash.Type.Map <- Keyword.get(member_config, :type),
+         fields when is_list(fields) <-
+           member_config |> Keyword.get(:constraints, []) |> Keyword.get(:fields) do
+      fields
+      |> Enum.filter(fn {field_name, _} -> invalid_name?(field_name) end)
+      |> Enum.map(fn {field_name, _} ->
+        {attribute_name, {:member_field, member_name}, field_name, better_name(field_name)}
+      end)
+    else
+      _ -> []
+    end
+  end
+
+  @doc false
+  def invalid_name?(name), do: Regex.match?(~r/_+\d|\?/, to_string(name))
+
+  @doc false
+  def better_name(name) do
+    name
+    |> to_string()
+    |> String.replace(~r/_+\d/, &String.trim_leading(&1, "_"))
+    |> String.replace("?", "")
+  end
+
+  defp format_errors(resource, errors) do
+    details =
+      errors
+      |> Enum.group_by(fn {attribute_name, _kind, _name, _suggested} -> attribute_name end)
+      |> Enum.map_join("\n\n", &format_attribute_group/1)
+
+    {:error,
+     Spark.Error.DslError.exception(
+       message: """
+       Invalid union member names on resource #{inspect(resource)}.
+
+       These names become Kotlin identifiers in the sealed class generated for the
+       attribute, and a question mark or an underscore before a digit is not valid there.
+
+       #{details}
+
+       Rename them on the resource. A `field_names` mapping does not help: the sealed
+       class is generated from the constraint names directly.
+       """
+     )}
+  end
+
+  defp format_attribute_group({attribute_name, errors}) do
+    lines =
+      Enum.map_join(errors, "\n", fn
+        {_attribute_name, :union_member, name, suggested} ->
+          "  - union member #{name} → #{suggested}"
+
+        {_attribute_name, {:member_field, member_name}, name, suggested} ->
+          "  - field #{name} of union member #{member_name} → #{suggested}"
+      end)
+
+    "Attribute #{inspect(attribute_name)}:\n#{lines}"
+  end
+end

--- a/lib/ash_kotlin_multiplatform/rpc.ex
+++ b/lib/ash_kotlin_multiplatform/rpc.ex
@@ -183,6 +183,7 @@ defmodule AshKotlinMultiplatform.Rpc do
   use Spark.Dsl.Extension,
     sections: [@rpc],
     verifiers: [
+      AshKotlinMultiplatform.Rpc.Verifiers.VerifyPublicActions,
       AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities,
       AshKotlinMultiplatform.Rpc.Verifiers.VerifyActionTypes
     ]

--- a/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_action_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_action_types.ex
@@ -320,7 +320,7 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyActionTypes do
     field_name_mappings = get_resource_field_mappings(embedded_module)
 
     attributes = Ash.Resource.Info.public_attributes(embedded_module)
-    calculations = Ash.Resource.Info.public_calculations(embedded_module)
+    calculations = AshKotlinMultiplatform.Resource.Info.public_field_calculations(embedded_module)
     aggregates = Ash.Resource.Info.public_aggregates(embedded_module)
     relationships = Ash.Resource.Info.public_relationships(embedded_module)
 
@@ -361,7 +361,7 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyActionTypes do
     field_name_mappings = get_resource_field_mappings(target_resource)
 
     attributes = Ash.Resource.Info.public_attributes(target_resource)
-    calculations = Ash.Resource.Info.public_calculations(target_resource)
+    calculations = AshKotlinMultiplatform.Resource.Info.public_field_calculations(target_resource)
     aggregates = Ash.Resource.Info.public_aggregates(target_resource)
     relationships = Ash.Resource.Info.public_relationships(target_resource)
 

--- a/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_public_actions.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_public_actions.ex
@@ -1,0 +1,179 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyPublicActions do
+  @moduledoc """
+  Refuses to generate a Kotlin client for an action the resource marks internal.
+
+  Ash documents `public? false` on an action as "internal-only and must not be
+  exposed by API extensions" (`deps/ash/lib/ash/resource/actions/shared_options.ex`,
+  ash 3.33.1). Nothing enforced that here: a `rpc_action` naming a non-public
+  action produced a fully typed client function for it, and the mistake showed
+  up — if at all — as a runtime failure long after the code shipped. An
+  author who wrote `public? false` to keep an action off the wire got the
+  opposite.
+
+  Four places can expose one, and all four are checked:
+
+    * the action a `rpc_action` names
+    * the `read_action` a `rpc_action` uses to find records for update/destroy
+    * the action a `typed_query` names
+    * the read action behind a public relationship, which the client loads
+      through the parent resource without ever naming it
+
+  The relationship check only looks at destinations carrying the
+  `AshKotlinMultiplatform.Resource` extension. A destination the generator does
+  not know about produces no client type, so its read action is not reachable
+  from Kotlin and is none of this verifier's business.
+  """
+  use Spark.Dsl.Verifier
+  alias Spark.Dsl.Verifier
+
+  @impl true
+  def verify(dsl) do
+    dsl
+    |> Verifier.get_entities([:kotlin_rpc])
+    |> Enum.reduce_while(:ok, fn entity, acc ->
+      case verify_resource(entity) do
+        :ok -> {:cont, acc}
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp verify_resource(%{resource: resource} = entity) do
+    rpc_actions = Map.get(entity, :rpc_actions, [])
+    typed_queries = Map.get(entity, :typed_queries, [])
+
+    with :ok <- verify_rpc_actions(resource, rpc_actions),
+         :ok <- verify_typed_queries(resource, typed_queries) do
+      verify_relationship_read_actions(resource)
+    end
+  end
+
+  @doc false
+  def verify_rpc_actions(resource, rpc_actions) do
+    Enum.reduce_while(rpc_actions, :ok, fn rpc_action, acc ->
+      with :ok <- verify_action_public(resource, rpc_action),
+           :ok <- verify_read_action_public(resource, rpc_action) do
+        {:cont, acc}
+      else
+        error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp verify_action_public(resource, rpc_action) do
+    case Ash.Resource.Info.action(resource, rpc_action.action) do
+      nil ->
+        :ok
+
+      action ->
+        if public?(action) do
+          :ok
+        else
+          error("""
+          RPC action #{inspect(rpc_action.name)} on #{inspect(resource)} exposes action \
+          #{inspect(action.name)}, which is not `public?`.
+
+          Ash treats a non-public action as internal-only, so it must not reach a generated \
+          Kotlin client.
+
+          Either mark the action `public? true`, or drop `rpc_action #{inspect(rpc_action.name)}, \
+          #{inspect(action.name)}` from the `kotlin_rpc` block.
+          """)
+        end
+    end
+  end
+
+  defp verify_read_action_public(resource, rpc_action) do
+    read_action_name = Map.get(rpc_action, :read_action)
+    read_action = read_action_name && Ash.Resource.Info.action(resource, read_action_name)
+
+    if read_action && not public?(read_action) do
+      error("""
+      RPC action #{inspect(rpc_action.name)} on #{inspect(resource)} uses read_action \
+      #{inspect(read_action_name)}, which is not `public?`.
+
+      The read_action fetches the record the client names, so exposing it over RPC exposes \
+      whatever it can read.
+
+      Either mark #{inspect(read_action_name)} `public? true`, or point `read_action` at a \
+      public read action.
+      """)
+    else
+      :ok
+    end
+  end
+
+  @doc false
+  def verify_typed_queries(resource, typed_queries) do
+    Enum.reduce_while(typed_queries, :ok, fn typed_query, acc ->
+      case Ash.Resource.Info.action(resource, typed_query.action) do
+        nil ->
+          {:cont, acc}
+
+        action ->
+          if public?(action) do
+            {:cont, acc}
+          else
+            {:halt,
+             error("""
+             Typed query #{inspect(typed_query.name)} on #{inspect(resource)} references action \
+             #{inspect(action.name)}, which is not `public?`.
+
+             Ash treats a non-public action as internal-only, so it must not reach a generated \
+             Kotlin client.
+
+             Either mark the action `public? true`, or drop the \
+             `typed_query #{inspect(typed_query.name)}` entry.
+             """)}
+          end
+      end
+    end)
+  end
+
+  @doc false
+  def verify_relationship_read_actions(resource) do
+    resource
+    |> Ash.Resource.Info.public_relationships()
+    |> Enum.reduce_while(:ok, fn relationship, acc ->
+      destination = relationship.destination
+
+      with true <-
+             AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_resource?(destination),
+           read_action when not is_nil(read_action) <- resolve_read_action(relationship),
+           false <- public?(read_action) do
+        {:halt,
+         error("""
+         Relationship #{inspect(resource)}.#{relationship.name} points to #{inspect(destination)}, \
+         whose read action #{inspect(read_action.name)} is not `public?`.
+
+         The generated client loads a public relationship through its parent, which runs that read \
+         action — so a non-public read action on the destination is exposed without ever being \
+         named in the `kotlin_rpc` block.
+
+         Either mark #{inspect(destination)}'s #{inspect(read_action.name)} action `public? true`, \
+         or make the relationship `public? false`.
+         """)}
+      else
+        _ -> {:cont, acc}
+      end
+    end)
+  end
+
+  defp resolve_read_action(relationship) do
+    if relationship.read_action do
+      Ash.Resource.Info.action(relationship.destination, relationship.read_action)
+    else
+      Ash.Resource.Info.primary_action(relationship.destination, :read)
+    end
+  end
+
+  defp public?(action), do: Map.get(action, :public?, true)
+
+  defp error(message) do
+    {:error, Spark.Error.DslError.exception(message: String.trim_trailing(message))}
+  end
+end

--- a/test/ash_kotlin_multiplatform/codegen/non_field_calculations_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/non_field_calculations_test.exs
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Test.NonFieldCalculations.Report do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("Report")
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :title, :string, public?: true
+  end
+
+  calculations do
+    calculate :headline, :string, expr(title) do
+      public? true
+    end
+
+    # Not a struct field: Ash keeps its value in the record's `calculations`
+    # map, so the generated data class has nowhere to put it.
+    calculate :ranking_score, :integer, expr(1) do
+      public? true
+      field? false
+    end
+  end
+
+  actions do
+    defaults [:read]
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.NonFieldCalculations.BadlyNamed do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("BadlyNamed")
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  calculations do
+    # `score_1` would be rejected by VerifyFieldNames if it were generated.
+    # It is not, so the name never reaches Kotlin and must not fail the build.
+    calculate :score_1, :integer, expr(1) do
+      public? true
+      field? false
+    end
+  end
+
+  actions do
+    defaults [:read]
+  end
+end
+
+defmodule AshKotlinMultiplatform.Codegen.NonFieldCalculationsTest do
+  @moduledoc """
+  A calculation declared `field?: false` is not a field on the resource struct
+  — Ash stores its value in the record's `calculations` map instead. The
+  generator treated every public calculation as a field, so such a calculation
+  reached the Kotlin data class, the filter input and the name verifier, none
+  of which can ever see a value for it.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Codegen.FilterTypes
+  alias AshKotlinMultiplatform.Resource.Verifiers.VerifyFieldNames
+  alias AshKotlinMultiplatform.Test.NonFieldCalculations.BadlyNamed
+  alias AshKotlinMultiplatform.Test.NonFieldCalculations.Report
+
+  test "the filter input omits a field?: false calculation" do
+    kotlin = FilterTypes.generate_filter_type(Report)
+
+    assert kotlin =~ "val headline:"
+    refute kotlin =~ "rankingScore"
+  end
+
+  test "name verification ignores a field?: false calculation" do
+    assert :ok = VerifyFieldNames.verify(BadlyNamed.spark_dsl_config())
+  end
+end

--- a/test/ash_kotlin_multiplatform/resource/verify_union_member_names_test.exs
+++ b/test/ash_kotlin_multiplatform/resource/verify_union_member_names_test.exs
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Resource.Verifiers.VerifyUnionMemberNamesTest do
+  @moduledoc """
+  A union attribute is the one place where a name written inside `constraints`
+  becomes a Kotlin identifier. `ResourceSchemas.generate_sealed_class/1` turns
+  each member name into a subclass name and each map member's field names into
+  properties, so `is_valid?` emitted `data class IsValid?(` and a member field
+  `ok?` emitted `val ok?:` — neither of which Kotlin will compile.
+
+  Every other constraint name in this generator is erased: a plain `:map`
+  attribute becomes an untyped map, a tuple a `List`, so their field names never
+  reach Kotlin and must not be rejected.
+  """
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  describe "union attributes" do
+    test "rejects a union member name that is not a valid Kotlin identifier" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyUnionMemberNames.BadMember do
+            @moduledoc false
+            use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+            kotlin_multiplatform do
+              type_name("BadMember")
+            end
+
+            attributes do
+              uuid_primary_key :id
+
+              attribute :content, :union do
+                constraints types: [
+                              text: [type: :string],
+                              is_valid?: [type: :boolean]
+                            ]
+
+                public? true
+              end
+            end
+
+            actions do
+              defaults [:read]
+            end
+          end
+        end
+
+      assert error.message =~ "is_valid?"
+      assert error.message =~ "content"
+      assert error.message =~ "union member"
+    end
+
+    test "rejects an invalid field name inside a map union member" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyUnionMemberNames.BadMemberField do
+            @moduledoc false
+            use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+            kotlin_multiplatform do
+              type_name("BadMemberField")
+            end
+
+            attributes do
+              uuid_primary_key :id
+
+              attribute :content, :union do
+                constraints types: [
+                              note: [
+                                type: :map,
+                                constraints: [
+                                  fields: [body: [type: :string], ok?: [type: :boolean]]
+                                ]
+                              ]
+                            ]
+
+                public? true
+              end
+            end
+
+            actions do
+              defaults [:read]
+            end
+          end
+        end
+
+      assert error.message =~ "ok?"
+      assert error.message =~ "note"
+      assert error.message =~ "content"
+    end
+
+    test "accepts valid union member and member field names" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyUnionMemberNames.GoodUnion do
+          @moduledoc false
+          use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+          kotlin_multiplatform do
+            type_name("GoodUnion")
+          end
+
+          attributes do
+            uuid_primary_key :id
+
+            attribute :content, :union do
+              constraints types: [
+                            text: [type: :string],
+                            note: [
+                              type: :map,
+                              constraints: [
+                                fields: [body: [type: :string], pinned: [type: :boolean]]
+                              ]
+                            ]
+                          ]
+
+              public? true
+            end
+          end
+
+          actions do
+            defaults [:read]
+          end
+        end
+      end
+    end
+
+    test "ignores constraint names the generator erases" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyUnionMemberNames.ErasedNames do
+          @moduledoc false
+          use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+          kotlin_multiplatform do
+            type_name("ErasedNames")
+          end
+
+          attributes do
+            uuid_primary_key :id
+
+            # Becomes an untyped map in Kotlin: `is_valid?` is never emitted.
+            attribute :settings, :map do
+              constraints fields: [is_valid?: [type: :boolean]]
+              public? true
+            end
+
+            # Becomes a List in Kotlin: `x_1` is never emitted.
+            attribute :position, :tuple do
+              constraints fields: [x_1: [type: :integer], y_1: [type: :integer]]
+              public? true
+            end
+          end
+
+          actions do
+            defaults [:read]
+          end
+        end
+      end
+    end
+
+    test "ignores a non-public union attribute" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyUnionMemberNames.PrivateUnion do
+          @moduledoc false
+          use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+          kotlin_multiplatform do
+            type_name("PrivateUnion")
+          end
+
+          attributes do
+            uuid_primary_key :id
+
+            attribute :content, :union do
+              constraints types: [is_valid?: [type: :boolean]]
+            end
+          end
+
+          actions do
+            defaults [:read]
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/ash_kotlin_multiplatform/rpc/verifiers/verify_public_actions_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/verifiers/verify_public_actions_test.exs
@@ -1,0 +1,364 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+# Resources used by the relationship checks live at the top level: a resource
+# defined inside a test body is not fully compiled when the domain that points
+# at it is verified, so `Ash.Resource.Info.public_relationships/1` returns
+# nothing and the check silently passes.
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateReadDestination do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("PrivateReadDestination")
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+  end
+
+  actions do
+    read :read do
+      primary? true
+      public? false
+    end
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.PublicReadDestination do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("PublicReadDestination")
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+  end
+
+  actions do
+    defaults [:read]
+
+    default_accept [:name]
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.PlainDestination do
+  @moduledoc false
+  use Ash.Resource, domain: nil
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  actions do
+    read :read do
+      primary? true
+      public? false
+    end
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPrivateDestination do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("SourceWithPrivateDestination")
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  relationships do
+    belongs_to :destination,
+               AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateReadDestination do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read]
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPublicDestination do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("SourceWithPublicDestination")
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  relationships do
+    belongs_to :destination,
+               AshKotlinMultiplatform.Test.VerifyPublicActions.PublicReadDestination do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read]
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPlainDestination do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("SourceWithPlainDestination")
+  end
+
+  attributes do
+    uuid_primary_key :id
+  end
+
+  relationships do
+    belongs_to :destination, AshKotlinMultiplatform.Test.VerifyPublicActions.PlainDestination do
+      public? true
+    end
+  end
+
+  actions do
+    defaults [:read]
+  end
+end
+
+defmodule AshKotlinMultiplatform.Test.VerifyPublicActions.MixedActions do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("MixedActions")
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :name, :string, public?: true
+  end
+
+  actions do
+    default_accept [:name]
+
+    read :read do
+      primary? true
+    end
+
+    read :internal_lookup do
+      public? false
+    end
+
+    update :rename do
+      accept [:name]
+    end
+  end
+end
+
+defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyPublicActionsTest do
+  @moduledoc """
+  A non-public action must never reach the generated Kotlin client.
+
+  Ash documents `public? false` as "internal-only and must not be exposed by API
+  extensions". Before this verifier the generator happily emitted a client
+  function for such an action, so the mistake surfaced only as a runtime
+  failure — or not at all.
+  """
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  alias AshKotlinMultiplatform.Test.VerifyPublicActions.MixedActions
+
+  describe "rpc_action" do
+    test "rejects an action that is not public?" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateActionDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource MixedActions
+            end
+
+            kotlin_rpc do
+              resource MixedActions do
+                rpc_action(:lookup, :internal_lookup)
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "not `public?`"
+      assert error.message =~ "internal_lookup"
+      assert error.message =~ "lookup"
+    end
+
+    test "accepts an action that is public?" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PublicActionDomain do
+          @moduledoc false
+          use Ash.Domain,
+            extensions: [AshKotlinMultiplatform.Rpc],
+            validate_config_inclusion?: false
+
+          resources do
+            resource MixedActions
+          end
+
+          kotlin_rpc do
+            resource MixedActions do
+              rpc_action(:list, :read)
+            end
+          end
+        end
+      end
+    end
+
+    test "rejects a read_action that is not public?" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateReadActionDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource MixedActions
+            end
+
+            kotlin_rpc do
+              resource MixedActions do
+                rpc_action :rename, :rename do
+                  read_action :internal_lookup
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "not `public?`"
+      assert error.message =~ "internal_lookup"
+      assert error.message =~ "read_action"
+    end
+  end
+
+  describe "typed_query" do
+    test "rejects an action that is not public?" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateTypedQueryDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource MixedActions
+            end
+
+            kotlin_rpc do
+              resource MixedActions do
+                typed_query :names, :internal_lookup do
+                  fields(["id", "name"])
+                  kotlin_result_type_name("NamesResult")
+                  kotlin_fields_const_name("NAMES_FIELDS")
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "not `public?`"
+      assert error.message =~ "internal_lookup"
+      assert error.message =~ "names"
+    end
+  end
+
+  describe "relationship read actions" do
+    test "rejects a public relationship whose destination read action is not public?" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateRelDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPrivateDestination
+              resource AshKotlinMultiplatform.Test.VerifyPublicActions.PrivateReadDestination
+            end
+
+            kotlin_rpc do
+              resource AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPrivateDestination do
+                rpc_action(:list, :read)
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "not `public?`"
+      assert error.message =~ "destination"
+      assert error.message =~ "PrivateReadDestination"
+    end
+
+    test "accepts a public relationship whose destination read action is public?" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PublicRelDomain do
+          @moduledoc false
+          use Ash.Domain,
+            extensions: [AshKotlinMultiplatform.Rpc],
+            validate_config_inclusion?: false
+
+          resources do
+            resource AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPublicDestination
+            resource AshKotlinMultiplatform.Test.VerifyPublicActions.PublicReadDestination
+          end
+
+          kotlin_rpc do
+            resource AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPublicDestination do
+              rpc_action(:list, :read)
+            end
+          end
+        end
+      end
+    end
+
+    test "ignores a destination that is not a Kotlin resource" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyPublicActions.PlainRelDomain do
+          @moduledoc false
+          use Ash.Domain,
+            extensions: [AshKotlinMultiplatform.Rpc],
+            validate_config_inclusion?: false
+
+          resources do
+            resource AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPlainDestination
+            resource AshKotlinMultiplatform.Test.VerifyPublicActions.PlainDestination
+          end
+
+          kotlin_rpc do
+            resource AshKotlinMultiplatform.Test.VerifyPublicActions.SourceWithPlainDestination do
+              rpc_action(:list, :read)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Three of the four compile-time checks from #34. Each is a separate commit.

`0b50ce0` is done in full. The other two are done as this repo's generator
actually behaves, which is not always as upstream's does — see **What was
deferred** for the one that does not apply here and the one that is already
satisfied.

## What landed

### 1. `feat: refuse to generate a client for a non-public action` (#34, `0b50ce0`)

Ash documents `public? false` on an action as "internal-only and must not be
exposed by API extensions" (`deps/ash/lib/ash/resource/actions/shared_options.ex`,
ash 3.33.1). Nothing enforced that here: a `rpc_action` naming a non-public
action produced a fully typed Kotlin client function for it, so an author who
wrote `public? false` to keep an action off the wire got the opposite.

`AshKotlinMultiplatform.Rpc.Verifiers.VerifyPublicActions` closes all four
routes to exposure:

| Route | Check |
| --- | --- |
| `rpc_action :x, :action` | the action is `public?` |
| `rpc_action ... read_action :y` | the read action is `public?` |
| `typed_query :q, :action` | the action is `public?` |
| a public relationship | the destination's read action is `public?` |

The relationship check only looks at destinations carrying the
`AshKotlinMultiplatform.Resource` extension. The generator emits no client type
for anything else, so its read action is unreachable from Kotlin.

### 2. `fix: keep field?: false calculations out of the generated Kotlin` (#34, `0ba40c2`)

Ash stores such a calculation's value in the record's `calculations` map rather
than as a struct key, so nothing can read it off a record. The generator treated
every public calculation as a field anyway: it landed in the data class, the
filter input, type discovery and field-name verification.

The last of those could fail a build outright — a `field?: false` calculation
named `score_1` was rejected for a name that never reached Kotlin.

`AshKotlinMultiplatform.Resource.Info.public_field_calculations/1` is now the
single place that decides, so a new call site cannot leak one back in. Five call
sites moved onto it.

### 3. `feat: reject union member names Kotlin cannot compile` (#34, `ffab669`)

A union attribute is the one place in this generator where a name written inside
`constraints` becomes a Kotlin identifier. `ResourceSchemas.generate_sealed_class/1`
turns each member name into a subclass name and each field of a map member into
a property. Verified by generating it:

```kotlin
data class IsValid?(          // union member :is_valid?
    val value: String
) : ContentUnion()

data class Html1(             // union member :html_1
    val body1: @Contextual Any? = null,
    val ok?: @Contextual Any? = null   // member field :ok?
) : ContentUnion()
```

`data class IsValid?(` and `val ok?:` are not valid Kotlin. The blocking Kotlin
gate would have caught them; no Elixir verifier did, because the resource
verifiers only ever looked at top-level field names.

Deliberately narrow, and this is where the port departs from upstream: every
other constraint name this generator meets is **erased** before it reaches
Kotlin — a `:map` attribute becomes an untyped map (`type_mapper.ex:220`), a
`:tuple` a `List`, a union outside a resource attribute a `@Contextual Any`.
Rejecting those would fail builds over names that never appear in the output.
`resource_schemas.ex:329` is the only site in `lib/` that turns map `fields:`
constraint names into Kotlin identifiers.

## What was deferred, and why

**`444fc60` — walk map field-name validation through NewType wrappers and array
`:items`.** Its premise does not hold in this repo. Upstream generates a typed
TypeScript object from a map's `fields:` constraints, so a nested invalid name
is a real defect. Here those names are erased (see above), and an array or
NewType wrapper around a union never produces a sealed class at all —
`ResourceSchemas.collect_types_from_attribute/4` tests `type == Ash.Type.Union`
exactly, so `{:array, Ash.Type.Union}` and a NewType-of-union are not collected.
Porting it as written would reject configurations whose generated Kotlin is
fine. Worth its own issue, together with the question of whether an
array-of-union attribute should get a sealed class in the first place.

**`6200290` — skip field-name validation when an explicit mapping exists.**
Already satisfied. Upstream's `Resource.Info.get_mapped_field_name/2` returns
`nil` when there is no mapping, so its verifier validated `nil` and needed the
guard. This repo's returns the original field name
(`resource/info.ex:100`), so `VerifyFieldNames` already validates the mapped
name when a mapping exists and the original otherwise. No double-check to
remove.

## Breaking changes

Two of the three reject configurations that compiled before. `CHANGELOG.md`
marks both.

- **Non-public actions.** A project exposing one now fails to compile. That is
  the point — it was exposing something it should not — and the error names
  the action and says whether to mark it `public? true` or drop the entry.
- **Union member names.** A project with a member named `is_valid?` now fails to
  compile. Its generated Kotlin did not compile either, so nothing that worked
  stops working.

Neither warns instead of failing. A warning on the first is wrong: the whole
value of the check is that the client is never generated, and a warning still
generates it. A warning on the second is pointless: the Kotlin compile fails
either way, and failing in Elixir with the attribute and member named is
strictly the better error.

## Error messages

```
RPC action :lookup on MyApp.Report exposes action :internal_lookup, which is not `public?`.

Ash treats a non-public action as internal-only, so it must not reach a generated Kotlin client.

Either mark the action `public? true`, or drop `rpc_action :lookup, :internal_lookup` from the `kotlin_rpc` block.
```

```
Relationship MyApp.Author.secrets points to MyApp.Secret, whose read action :read is not `public?`.

The generated client loads a public relationship through its parent, which runs that read action — so a
non-public read action on the destination is exposed without ever being named in the `kotlin_rpc` block.

Either mark MyApp.Secret's :read action `public? true`, or make the relationship `public? false`.
```

```
Invalid union member names on resource MyApp.Report.

These names become Kotlin identifiers in the sealed class generated for the
attribute, and a question mark or an underscore before a digit is not valid there.

Attribute :content:
  - union member is_valid? → is_valid
  - field ok? of union member note → ok
  - field v_1 of union member note → v1

Rename them on the resource. A `field_names` mapping does not help: the sealed
class is generated from the constraint names directly.
```

## Test plan

`171 tests, 0 failures` (was 157). 14 new tests, all through `Spark.Test`, so
each asserts on what a real compile of a real DSL module produces.

Every verifier gets both sides:

- **Rejects**: a non-public action, a non-public `read_action`, a non-public
  typed-query action, a relationship into a private read action, a bad union
  member name, a bad field name in a map union member. Each asserts the message
  names the offending action or field, not just that it failed.
- **Accepts**: a public action, a relationship into a public read action, a
  destination that is not a Kotlin resource, valid union names, and — the case
  `6200290` exists to protect — `:map` and `:tuple` constraint names the
  generator erases, which must not be rejected. A `field?: false` calculation
  named `score_1` compiles rather than failing the build.

Also run: `mix compile --force --warnings-as-errors` clean, and
`mix ash_kotlin_multiplatform.gen_kotlin_fixture` produces a byte-identical
fixture, so the generated Kotlin is unchanged for the test resources.

Closes #34
