### PR TITLE
Expose the rpc_action options the shared core already implements (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,12 +36,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A `get?` read that matches no record is a not-found error again when
+  codegen warnings are off. `Rpc.Pipeline.build_config/0` wired the pipeline's
+  `not_found_error?` to `AshKotlinMultiplatform.warn_on_missing_rpc_config?/0`,
+  a codegen-time warning switch, so
+  `config :ash_kotlin_multiplatform, warn_on_missing_rpc_config: false` also
+  turned every not-found into a successful `null`. It is now per-action, via
+  the `not_found_error?` option.
+
 - A destroy's generated return type said `Boolean`. The server returns the
   destroyed record: `AshIntrospection.Rpc.Pipeline.execute_destroy_action/3`
   bulk-destroys with `return_records?: true`. Nothing had noticed, because
   `FunctionCore.determine_return_type/1` had no caller.
 
 ### Added
+
+- Six `rpc_action` options, all additive — an `rpc_action` that sets none of
+  them behaves exactly as before
+  ([#25](https://github.com/udin-io/ash_kotlin_multiplatform/issues/25)). The
+  shared core already honoured four of them and the DSL declared none, so
+  those branches were unreachable: `AshIntrospection.Rpc.Pipeline` branches on
+  `get?`, applies `get_by`, reads `identities` and reads `not_found_error?`
+  off the config.
+
+  - `get?` makes a read return one record or nothing instead of a list. The
+    generated function's `data` becomes the resource rather than
+    `AshPage<Resource>`, and `filter`, `sort` and `page` leave its config.
+  - `get_by` names the fields the client sends to select that record, and
+    implies `get?`. It generates a `@Serializable` lookup class —
+    `GetAuthorGetBy` — so the fields are typed rather than a hand-assembled
+    map. The request must carry exactly those fields: a missing one would
+    widen the lookup into a `MultipleResults`, and an extra one reaches
+    `Ash.Query.do_filter/2`, which reads a map operand as an operator
+    expression and turns an exact lookup into an arbitrary predicate.
+  - `not_found_error?` (default `true`) chooses between a not-found error and
+    a successful `null` when a `get?` read matches nothing.
+  - `identities` (default `[:_primary_key]`) lists the identities an update or
+    destroy may be addressed by. `[]` means the action takes no identity and
+    finds its record some other way, such as from the actor. The verifier that
+    checks these names against the resource could never fail before, for want
+    of a way to set the option.
+  - `enable_filter?` and `enable_sort?` (both default `true`) remove that
+    parameter from the generated config class. The server refuses a request
+    that sends it anyway rather than dropping it: a stale client would
+    otherwise be handed the whole table with no way to know it asked for a
+    subset.
+
+  These shape an action's **API surface**, typically to keep a parameter off an
+  endpoint that has no use for it. They are **not** authorization — Ash
+  policies run on every request regardless of what the DSL exposes.
+
+  `allowed_loads` and `denied_loads` are not here. They need
+  `ash_introspection` 0.4.0, whose bump is a separate and breaking change.
 
 - **Breaking for existing users.** Compile-time check that every action
   reachable from the generated Kotlin client is `public?`. Ash documents

--- a/README.md
+++ b/README.md
@@ -394,7 +394,33 @@ kotlin_rpc do
 
     # Expose metadata fields
     rpc_action :list_items, :read do
-      expose_metadata [:total_count]
+      show_metadata [:total_count]
+    end
+
+    # Return one record instead of a list. `get_by` names the fields the
+    # client sends to select it, and implies `get?`.
+    rpc_action :get_item, :read do
+      get_by [:id]
+    end
+
+    # A miss answers with a null payload instead of a not-found error.
+    rpc_action :find_item, :read do
+      get_by [:slug]
+      not_found_error? false
+    end
+
+    # Address an update or destroy by a named identity rather than the
+    # primary key. `[]` means the action takes no identity at all.
+    rpc_action :rename_item, :rename do
+      identities [:unique_slug]
+    end
+
+    # Drop `filter` and `sort` from the generated config. The server refuses
+    # them too, so a stale client is told rather than quietly handed the
+    # unfiltered table.
+    rpc_action :recent_items, :recent do
+      enable_filter? false
+      enable_sort? false
     end
 
     # Define typed queries with preset filters
@@ -404,6 +430,11 @@ kotlin_rpc do
   end
 end
 ```
+
+These options shape the **API surface** of an action — typically to keep a
+parameter off an endpoint that has no use for it. They are **not**
+authorization. Ash policies run on every request regardless of what the DSL
+exposes, and narrowing the surface here neither adds nor removes a check.
 
 ## Phoenix Channel Support
 

--- a/lib/ash_kotlin_multiplatform/rpc.ex
+++ b/lib/ash_kotlin_multiplatform/rpc.ex
@@ -19,7 +19,10 @@ defmodule AshKotlinMultiplatform.Rpc do
       resource MyApp.Todo do
         rpc_action :list_todos, :read
         rpc_action :create_todo, :create
-        rpc_action :get_todo, :read
+
+        rpc_action :get_todo, :read do
+          get_by [:id]
+        end
 
         typed_query :my_query, :read,
           fields: ["id", "title"],
@@ -36,6 +39,11 @@ defmodule AshKotlinMultiplatform.Rpc do
     Struct representing an RPC action configuration.
 
     Defines the mapping between a named RPC endpoint and an Ash action.
+
+    The defaults here are the shape the client had before any of these options
+    existed, so an `rpc_action` that sets none of them behaves exactly as it did:
+    a read returns a list and accepts `filter` and `sort`, an update or destroy
+    is found by primary key, and a `get?` read that matches nothing is an error.
     """
     defstruct [
       :name,
@@ -43,6 +51,12 @@ defmodule AshKotlinMultiplatform.Rpc do
       :read_action,
       :show_metadata,
       :metadata_field_names,
+      identities: [:_primary_key],
+      get?: false,
+      get_by: [],
+      not_found_error?: true,
+      enable_filter?: true,
+      enable_sort?: true,
       __spark_metadata__: nil
     ]
   end
@@ -117,6 +131,30 @@ defmodule AshKotlinMultiplatform.Rpc do
     Metadata field naming: Use `metadata_field_names` to map invalid metadata field names
     (e.g., `field_1`, `is_valid?`) to valid Kotlin identifiers.
     Example: `metadata_field_names [field_1: :field1, is_valid?: :isValid]`
+
+    Single-record reads: `get?` makes a read return one record or nothing instead
+    of a list, and `get_by` names the fields the client sends to select it.
+    `get_by` implies `get?`. The generated function returns a nullable resource
+    and drops `filter`, `sort` and `page` from its config.
+
+        rpc_action :get_author, :read do
+          get_by [:id]
+        end
+
+    Record lookup for writes: `identities` lists the identities an update or
+    destroy may be addressed by. `[:_primary_key]` (the default) means the
+    primary key; a named identity must be defined on the resource; `[]` means
+    the action takes no identity at all and finds its record some other way,
+    such as from the actor.
+
+    Read surface: `enable_filter?` and `enable_sort?` both default to `true`.
+    Setting either to `false` removes that parameter from the generated config
+    class and makes the server reject a request that sends it anyway — a stale
+    client is told, rather than quietly handed the unfiltered table.
+
+    These options shape the API surface of an action. They are **not**
+    authorization. Ash policies run on every request regardless of what the DSL
+    exposes, and narrowing the surface here neither adds nor removes a check.
     """,
     schema: [
       name: [
@@ -141,6 +179,37 @@ defmodule AshKotlinMultiplatform.Rpc do
         type: {:list, {:tuple, [:atom, :atom]}},
         doc: "Map metadata field names to valid Kotlin identifiers",
         default: []
+      ],
+      identities: [
+        type: {:list, :atom},
+        doc:
+          "Identities an update or destroy may be addressed by. `:_primary_key` names the primary key; `[]` means the action takes no identity",
+        default: [:_primary_key]
+      ],
+      get?: [
+        type: :boolean,
+        doc: "Return a single record or nothing instead of a list. Read actions only",
+        default: false
+      ],
+      get_by: [
+        type: {:wrap_list, :atom},
+        doc: "Fields the client sends to select one record. Implies `get?`. Read actions only",
+        default: []
+      ],
+      not_found_error?: [
+        type: :boolean,
+        doc: "Whether a `get?` read matching no record is an error rather than a null result",
+        default: true
+      ],
+      enable_filter?: [
+        type: :boolean,
+        doc: "Whether the client may send `filter` on a list read",
+        default: true
+      ],
+      enable_sort?: [
+        type: :boolean,
+        doc: "Whether the client may send `sort` on a list read",
+        default: true
       ]
     ],
     args: [:name, :action]

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex
@@ -31,16 +31,22 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
   - `:identities` - List of identity atoms for record lookup (update/destroy actions)
   - `:supports_pagination` - Whether the action supports pagination (list reads)
   - `:supports_filtering` - Whether the action supports filtering (list reads)
+  - `:supports_sorting` - Whether the action supports sorting (list reads)
+  - `:get_by` - Fields the client sends to select one record (`[]` when none)
   - `:action_input_type` - Whether the input is :none, :required, or :optional
   - `:is_get_action` - Whether this is a get action (returns single or null)
+
+  `rpc_action` is read with `Map.get/3` throughout rather than by struct field,
+  because the codegen tests pass a bare map for actions that set no options.
   """
   def get_action_context(resource, action, rpc_action) do
     # Check both Ash's native get? and RPC's get?/get_by options
     ash_get? = action.type == :read and Map.get(action, :get?, false)
     rpc_get? = Map.get(rpc_action, :get?, false)
-    rpc_get_by = (Map.get(rpc_action, :get_by) || []) != []
+    get_by = if action.type == :read, do: Map.get(rpc_action, :get_by) || [], else: []
 
-    is_get_action = ash_get? or rpc_get? or rpc_get_by
+    is_get_action = ash_get? or rpc_get? or get_by != []
+    list_read? = action.type == :read and not is_get_action
 
     identities =
       if action.type in [:update, :destroy] do
@@ -52,10 +58,10 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
     %{
       requires_tenant: AshKotlinMultiplatform.requires_tenant_parameter?(resource),
       identities: identities,
-      supports_pagination:
-        action.type == :read and not is_get_action and
-          ActionIntrospection.action_supports_pagination?(action),
-      supports_filtering: action.type == :read and not is_get_action,
+      supports_pagination: list_read? and ActionIntrospection.action_supports_pagination?(action),
+      supports_filtering: list_read? and Map.get(rpc_action, :enable_filter?, true),
+      supports_sorting: list_read? and Map.get(rpc_action, :enable_sort?, true),
+      get_by: get_by,
       action_input_type: ActionIntrospection.action_input_type(resource, action),
       is_get_action: is_get_action
     }
@@ -97,6 +103,14 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
         fields
       end
 
+    # Add the get_by lookup for a single-record read
+    fields =
+      if context.get_by != [] do
+        fields ++ [{:get_by, "#{rpc_action_name_pascal}GetBy", false}]
+      else
+        fields
+      end
+
     # Add input field based on input type
     fields =
       case context.action_input_type do
@@ -121,11 +135,14 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
     # Add filter and sort for list reads
     fields =
       if context.supports_filtering do
-        fields ++
-          [
-            {:filter, "Map<String, JsonElement>?", true, "null"},
-            {:sort, "String?", true, "null"}
-          ]
+        fields ++ [{:filter, "Map<String, JsonElement>?", true, "null"}]
+      else
+        fields
+      end
+
+    fields =
+      if context.supports_sorting do
+        fields ++ [{:sort, "String?", true, "null"}]
       else
         fields
       end
@@ -168,9 +185,43 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.ConfigBuilder do
       end)
 
     """
-    data class #{rpc_action_name_pascal}Config(
+    #{build_get_by_type(resource, context.get_by, rpc_action_name_pascal)}data class #{rpc_action_name_pascal}Config(
     #{Enum.join(field_defs, ",\n")}
     )
+    """
+  end
+
+  # The lookup fields of a single-record read, as their own @Serializable class
+  # rather than a Map<String, JsonElement>: the server requires exactly these
+  # fields and rejects anything else, so a client that has to assemble the map by
+  # hand learns at runtime what the compiler could have told it.
+  #
+  # @SerialName carries the resource's own field name, matching
+  # InputTypes.generate_input_type/2 — `Runner` snake-cases every incoming key,
+  # so both spellings arrive, and emitting one keeps the two request payloads
+  # spelled the same way on the wire.
+  defp build_get_by_type(_resource, [], _pascal_name), do: ""
+
+  defp build_get_by_type(resource, get_by, pascal_name) do
+    field_defs =
+      Enum.map_join(get_by, ",\n", fn field_name ->
+        attribute = Ash.Resource.Info.attribute(resource, field_name)
+        kotlin_type = TypeMapper.get_kotlin_type_for_type(attribute.type, attribute.constraints)
+        camel_name = Helpers.snake_to_camel_case(field_name)
+        serial_name = Atom.to_string(field_name)
+
+        annotation =
+          if serial_name == camel_name, do: "", else: "    @SerialName(\"#{serial_name}\")\n"
+
+        "#{annotation}    val #{camel_name}: #{kotlin_type}"
+      end)
+
+    """
+    @Serializable
+    data class #{pascal_name}GetBy(
+    #{field_defs}
+    )
+
     """
   end
 

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/payload_builder.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/helpers/payload_builder.ex
@@ -49,6 +49,14 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.PayloadBuilder do
         payload_lines
       end
 
+    # Add the get_by lookup for a single-record read
+    payload_lines =
+      if context.get_by != [] do
+        payload_lines ++ ["put(\"getBy\", ashRpcJson.encodeToJsonElement(config.getBy))"]
+      else
+        payload_lines
+      end
+
     # Add input if needed
     payload_lines =
       case context.action_input_type do
@@ -88,10 +96,15 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.Helpers.PayloadBuilder do
     payload_lines =
       if context.supports_filtering do
         payload_lines ++
-          [
-            "config.filter?.let { put(\"filter\", ashRpcJson.encodeToJsonElement(it)) }",
-            "config.sort?.let { put(\"sort\", it) }"
-          ]
+          ["config.filter?.let { put(\"filter\", ashRpcJson.encodeToJsonElement(it)) }"]
+      else
+        payload_lines
+      end
+
+    # Add sort if supported
+    payload_lines =
+      if context.supports_sorting do
+        payload_lines ++ ["config.sort?.let { put(\"sort\", it) }"]
       else
         payload_lines
       end

--- a/lib/ash_kotlin_multiplatform/rpc/pipeline.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/pipeline.ex
@@ -38,6 +38,10 @@ defmodule AshKotlinMultiplatform.Rpc.Pipeline do
 
   @doc """
   Builds the Kotlin-specific configuration map for the shared pipeline.
+
+  `not_found_error?` is per-action — see `build_config/1`. This arity carries
+  the shared default, `true`, and serves the field selector and the error
+  builder, neither of which reads that key.
   """
   def build_config do
     %{
@@ -46,8 +50,22 @@ defmodule AshKotlinMultiplatform.Rpc.Pipeline do
       field_names_callback: :interop_field_names,
       get_original_field_name: &get_original_field_name/2,
       format_field_for_client: &format_field_for_client/3,
-      not_found_error?: AshKotlinMultiplatform.warn_on_missing_rpc_config?()
+      not_found_error?: true
     }
+  end
+
+  @doc """
+  Builds the pipeline configuration for one RPC action.
+
+  Only `not_found_error?` varies by action: it decides whether a `get?` read
+  that matches no record is an `Ash.Error.Query.NotFound` or a successful
+  `null`. It used to be wired to
+  `AshKotlinMultiplatform.warn_on_missing_rpc_config?/0`, a codegen-time
+  warning switch, so a project that silenced codegen warnings also turned every
+  not-found into a null result.
+  """
+  def build_config(rpc_action) do
+    Map.put(build_config(), :not_found_error?, Map.get(rpc_action, :not_found_error?, true))
   end
 
   @doc """
@@ -57,7 +75,7 @@ defmodule AshKotlinMultiplatform.Rpc.Pipeline do
   """
   @spec execute_ash_action(Request.t()) :: {:ok, term()} | {:error, term()}
   def execute_ash_action(%Request{} = request) do
-    SharedPipeline.execute_ash_action(request, build_config())
+    SharedPipeline.execute_ash_action(request, build_config(request.rpc_action))
   end
 
   @doc """

--- a/lib/ash_kotlin_multiplatform/rpc/runner.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/runner.ex
@@ -138,7 +138,7 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
 
   defp execute_action(domain, resource, rpc_action, params, actor, tenant, context) do
     action_name = rpc_action.action
-    action_info = Ash.Resource.Info.action(resource, action_name)
+    action_info = resource |> Ash.Resource.Info.action(action_name) |> apply_get?(rpc_action)
 
     with {:ok, request} <-
            build_request(
@@ -175,7 +175,9 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
       |> dsl_metadata_fields(rpc_action)
       |> narrow_metadata_fields(parse_metadata_fields(params))
 
-    with {:ok, {select, load, extraction_template}} <-
+    with :ok <- check_read_surface(rpc_action, filter, sort),
+         {:ok, get_by} <- parse_get_by(params, rpc_action),
+         {:ok, {select, load, extraction_template}} <-
            select_fields(resource, action, fields) do
       {:ok,
        %Request{
@@ -185,6 +187,7 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
          rpc_action: rpc_action,
          input: input,
          identity: identity,
+         get_by: get_by,
          filter: filter,
          sort: sort,
          pagination: page,
@@ -258,6 +261,78 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
 
   defp get_record_for_validation(_resource, nil, _opts) do
     {:error, {:missing_required_parameter, :identity}}
+  end
+
+  # ---------------------------------------------------------------------------
+  # Single-Record Reads
+  # ---------------------------------------------------------------------------
+
+  # `AshIntrospection.Rpc.Pipeline.execute_read_action/3` branches on the *Ash*
+  # action's `get?`, so a DSL-level `get?` has to reach it as one. Only the
+  # branch decision reads the field — the query is built from `action.name` —
+  # so overriding it here selects `Ash.read_one/1` and nothing else.
+  #
+  # `get_by` implies `get?`: naming the fields that select one record is the
+  # whole statement, and requiring both would let a config ask for a lookup key
+  # and a list in the same breath.
+  defp apply_get?(%{type: :read} = action, rpc_action) do
+    if Map.get(rpc_action, :get?, false) or configured_get_by(rpc_action) != [] do
+      %{action | get?: true}
+    else
+      action
+    end
+  end
+
+  defp apply_get?(action, _rpc_action), do: action
+
+  defp configured_get_by(rpc_action), do: Map.get(rpc_action, :get_by) || []
+
+  # The client must send exactly the fields the DSL configured — no more, no
+  # fewer. A missing field would widen the lookup to every record matching the
+  # rest, and `Ash.read_one/1` answers that with a `MultipleResults` naming
+  # nothing the caller can act on; an extra field would reach
+  # `Ash.Query.do_filter/2` as an arbitrary predicate.
+  defp parse_get_by(params, rpc_action) do
+    allowed = configured_get_by(rpc_action)
+    sent = normalize_get_by(params["getBy"])
+
+    sent_keys = sent |> Map.keys() |> MapSet.new()
+    allowed_keys = MapSet.new(allowed)
+
+    missing = allowed_keys |> MapSet.difference(sent_keys) |> Enum.sort()
+    extra = sent_keys |> MapSet.difference(allowed_keys) |> Enum.sort()
+
+    cond do
+      extra != [] -> {:error, {:unexpected_get_by_fields, extra, allowed}}
+      missing != [] -> {:error, {:missing_get_by_fields, missing}}
+      allowed == [] -> {:ok, nil}
+      true -> {:ok, sent}
+    end
+  end
+
+  defp normalize_get_by(get_by) when is_map(get_by), do: convert_keys_to_atoms(get_by)
+  defp normalize_get_by(_), do: %{}
+
+  # ---------------------------------------------------------------------------
+  # Read Surface
+  # ---------------------------------------------------------------------------
+
+  # `enable_filter?: false` and `enable_sort?: false` drop the parameter from the
+  # generated config class, so no current client can send it. Rejecting rather
+  # than dropping is the point: a stale client that still sends `filter` would
+  # otherwise be handed the whole table and have no way to know it asked for a
+  # subset. Same reasoning the core applied to `identity` on reads.
+  defp check_read_surface(rpc_action, filter, sort) do
+    cond do
+      not is_nil(filter) and not Map.get(rpc_action, :enable_filter?, true) ->
+        {:error, {:filter_not_supported, rpc_action.name}}
+
+      not is_nil(sort) and not Map.get(rpc_action, :enable_sort?, true) ->
+        {:error, {:sort_not_supported, rpc_action.name}}
+
+      true ->
+        :ok
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -478,25 +553,34 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
     end)
   end
 
-  # Field selection errors carry a field path and a suggestion the client can
-  # act on, so they are rendered from the shared `ErrorBuilder` rather than
-  # flattened into a generic "error". The message arrives as a template plus
-  # vars, which `render_message/2` fills in.
-  defp build_error_response({:invalid_fields, reason}) do
-    errors =
-      {:invalid_fields, reason}
-      |> ErrorBuilder.build_error_response(Pipeline.build_config())
-      |> List.wrap()
-      |> Enum.map(fn error ->
-        %{
-          "type" => to_string(error.type),
-          "message" => render_message(error.message, Map.get(error, :vars, %{})),
-          "shortMessage" => error.short_message,
-          "field" => error |> Map.get(:fields, []) |> List.first()
-        }
-      end)
+  # Field selection and getBy errors carry a field path and a suggestion the
+  # client can act on, so they are rendered from the shared `ErrorBuilder`
+  # rather than flattened into a generic "error". The message arrives as a
+  # template plus vars, which `render_message/2` fills in.
+  defp build_error_response({:invalid_fields, _reason} = error),
+    do: build_error_response_from_builder(error)
 
-    %{"success" => false, "errors" => errors}
+  defp build_error_response({:missing_get_by_fields, _missing} = error),
+    do: build_error_response_from_builder(error)
+
+  defp build_error_response({:unexpected_get_by_fields, _extra, _allowed} = error),
+    do: build_error_response_from_builder(error)
+
+  defp build_error_response({:invalid_get_by, _details} = error),
+    do: build_error_response_from_builder(error)
+
+  # Raised by the core pipeline, not here: a read that is sent an `identity` is
+  # refused. The shared message names `get_by` as the replacement, which is the
+  # reason this clause is worth having over the generic `inspect/1` fallback.
+  defp build_error_response({:identity_not_supported, _details} = error),
+    do: build_error_response_from_builder(error)
+
+  defp build_error_response({:filter_not_supported, rpc_action_name}) do
+    unsupported_read_parameter_response("filter", rpc_action_name, "enable_filter?")
+  end
+
+  defp build_error_response({:sort_not_supported, rpc_action_name}) do
+    unsupported_read_parameter_response("sort", rpc_action_name, "enable_sort?")
   end
 
   defp build_error_response({:action_not_found, action_name}) do
@@ -630,6 +714,43 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
     Enum.reduce(vars, message, fn {key, value}, acc ->
       String.replace(acc, "%{#{key}}", to_string(value))
     end)
+  end
+
+  defp build_error_response_from_builder(reason) do
+    errors =
+      reason
+      |> ErrorBuilder.build_error_response(Pipeline.build_config())
+      |> List.wrap()
+      |> Enum.map(fn error ->
+        %{
+          "type" => to_string(error.type),
+          "message" => render_message(error.message, Map.get(error, :vars, %{})),
+          "shortMessage" => error.short_message,
+          "field" => error |> Map.get(:fields, []) |> List.first() |> field_name_or_nil()
+        }
+      end)
+
+    %{"success" => false, "errors" => errors}
+  end
+
+  # `fields` reaches here as strings from field selection and as atoms from the
+  # getBy checks, and the client reads one shape.
+  defp field_name_or_nil(nil), do: nil
+  defp field_name_or_nil(field), do: to_string(field)
+
+  defp unsupported_read_parameter_response(parameter, rpc_action_name, dsl_option) do
+    %{
+      "success" => false,
+      "errors" => [
+        %{
+          "type" => "#{parameter}_not_supported",
+          "message" =>
+            "RPC action '#{rpc_action_name}' does not accept '#{parameter}'. " <>
+              "Set `#{dsl_option} true` on the rpc_action to enable it, or regenerate the client.",
+          "shortMessage" => "#{String.capitalize(parameter)} not supported"
+        }
+      ]
+    }
   end
 
   defp format_single_error(error) when is_exception(error) do

--- a/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex
@@ -4,10 +4,17 @@
 
 defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
   @moduledoc """
-  Verifies that all identities listed in RPC actions actually exist on the resource.
+  Verifies the lookup keys an RPC action names actually exist on the resource.
 
-  This catches configuration errors at compile time where an RPC action references
-  an identity that doesn't exist on the resource.
+  Two options name a way to select a record, and both are checked here because a
+  wrong name otherwise fails at runtime with an Ash error the client author
+  cannot trace back to the DSL entry that caused it:
+
+  * `identities` on an update or destroy — each must be `:_primary_key` or an
+    identity defined on the resource.
+  * `get_by` on a read — each must be a public attribute. The generated `GetBy`
+    data class takes its Kotlin type from that attribute, so a name that is not
+    one has no type to emit.
   """
   use Spark.Dsl.Verifier
   alias Spark.Dsl.Verifier
@@ -37,15 +44,38 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
   end
 
   defp validate_rpc_action_identities(resource, rpc_action, errors) do
-    # Get the action to check if it's update/destroy (identities only apply to these)
     action = Ash.Resource.Info.action(resource, rpc_action.action)
 
-    if action && action.type in [:update, :destroy] do
-      identities = Map.get(rpc_action, :identities, [:_primary_key])
-      validate_identities_exist(resource, rpc_action, identities, errors)
-    else
-      errors
+    cond do
+      is_nil(action) ->
+        errors
+
+      action.type in [:update, :destroy] ->
+        identities = Map.get(rpc_action, :identities, [:_primary_key])
+        validate_identities_exist(resource, rpc_action, identities, errors)
+
+      action.type == :read ->
+        validate_get_by_fields(resource, rpc_action, errors)
+
+      true ->
+        errors
     end
+  end
+
+  defp validate_get_by_fields(resource, rpc_action, errors) do
+    public_attributes =
+      resource |> Ash.Resource.Info.public_attributes() |> Enum.map(& &1.name)
+
+    rpc_action
+    |> Map.get(:get_by)
+    |> List.wrap()
+    |> Enum.reduce(errors, fn field, acc ->
+      if field in public_attributes do
+        acc
+      else
+        [{:get_by_not_an_attribute, rpc_action.name, field, public_attributes} | acc]
+      end
+    end)
   end
 
   defp validate_identities_exist(resource, rpc_action, identities, errors) do
@@ -96,14 +126,29 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
     {:error,
      Spark.Error.DslError.exception(
        message: """
-       Invalid identity configuration found in RPC actions.
+       Invalid record lookup configuration found in RPC actions.
 
        #{message_parts}
 
        Each identity listed in the `identities` option must either be `:_primary_key` (for the resource's primary key)
-       or the name of an identity defined on the resource.
+       or the name of an identity defined on the resource. Each field listed in `get_by` must be a public attribute.
        """
      )}
+  end
+
+  defp format_error_part({:get_by_not_an_attribute, rpc_name, field, public_attributes}) do
+    available_str =
+      case public_attributes do
+        [] -> "No public attributes are defined on this resource."
+        attributes -> "Public attributes: #{Enum.map_join(attributes, ", ", &inspect/1)}"
+      end
+
+    """
+    get_by field is not a public attribute:
+      - RPC action: #{rpc_name}
+      - Field: #{inspect(field)}
+      - #{available_str}
+    """
   end
 
   defp format_error_part(

--- a/test/ash_kotlin_multiplatform/rpc/codegen/rpc_action_options_codegen_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/codegen/rpc_action_options_codegen_test.exs
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.Codegen.RpcActionOptionsCodegenTest do
+  @moduledoc """
+  What the `rpc_action` options of #25 change in the emitted Kotlin.
+
+  The config class and the payload builder are a pair: the generated function
+  body reads `config.getBy`, `config.filter` and `config.sort`, and the class it
+  reads from is built separately. When the two disagreed the generated Kotlin
+  referenced a property that was never declared, which is the defect the
+  compile gate exists for — so both sides are asserted here rather than one.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Rpc.Codegen.Helpers.{ConfigBuilder, PayloadBuilder}
+  alias AshKotlinMultiplatform.Test.{Author, Book}
+
+  defp context(resource, action_name, rpc_action) do
+    action = Ash.Resource.Info.action(resource, action_name)
+    ConfigBuilder.get_action_context(resource, action, rpc_action)
+  end
+
+  defp config(resource, action_name, rpc_action, rpc_name) do
+    action = Ash.Resource.Info.action(resource, action_name)
+    ConfigBuilder.generate_config_type(resource, action, rpc_action, rpc_name)
+  end
+
+  defp payload(resource, action_name, rpc_action, rpc_name) do
+    PayloadBuilder.build_payload_code(rpc_name, context(resource, action_name, rpc_action))
+  end
+
+  describe "get_by" do
+    test "declares a typed GetBy class and a required config property" do
+      kotlin = config(Author, :read, %{get_by: [:id]}, :fetch_author)
+
+      assert kotlin =~ "@Serializable"
+      assert kotlin =~ "data class FetchAuthorGetBy("
+      assert kotlin =~ "val id: String"
+      assert kotlin =~ "val getBy: FetchAuthorGetBy"
+    end
+
+    test "sends the lookup under getBy" do
+      assert payload(Author, :read, %{get_by: [:id]}, :fetch_author) =~
+               ~s|put("getBy", ashRpcJson.encodeToJsonElement(config.getBy))|
+    end
+
+    test "makes the read a get, so it drops filter, sort and page" do
+      kotlin = config(Author, :read, %{get_by: [:id]}, :fetch_author)
+
+      refute kotlin =~ "val filter:"
+      refute kotlin =~ "val sort:"
+      refute kotlin =~ "val page:"
+    end
+
+    test "get? alone makes the read a get with no lookup class" do
+      kotlin = config(Author, :read, %{get?: true}, :current_author)
+
+      assert context(Author, :read, %{get?: true}).is_get_action
+      refute kotlin =~ "GetBy"
+      refute kotlin =~ "val filter:"
+    end
+
+    test "an action that configures none declares no GetBy" do
+      refute config(Author, :read, %{}, :list_authors) =~ "GetBy"
+    end
+  end
+
+  describe "enable_filter? and enable_sort?" do
+    test "both are declared by default" do
+      kotlin = config(Book, :read, %{}, :list_books)
+
+      assert kotlin =~ "val filter: Map<String, JsonElement>? = null"
+      assert kotlin =~ "val sort: String? = null"
+    end
+
+    test "enable_filter? false drops filter and keeps sort" do
+      kotlin = config(Book, :read, %{enable_filter?: false}, :list_books_unfiltered)
+
+      refute kotlin =~ "val filter:"
+      assert kotlin =~ "val sort: String? = null"
+    end
+
+    test "enable_sort? false drops sort and keeps filter" do
+      kotlin = config(Book, :read, %{enable_sort?: false}, :list_books_fixed_order)
+
+      assert kotlin =~ "val filter: Map<String, JsonElement>? = null"
+      refute kotlin =~ "val sort:"
+    end
+
+    test "the payload stops sending what the config stopped declaring" do
+      unfiltered = payload(Book, :read, %{enable_filter?: false}, :list_books_unfiltered)
+      unsorted = payload(Book, :read, %{enable_sort?: false}, :list_books_fixed_order)
+
+      refute unfiltered =~ "config.filter"
+      assert unfiltered =~ "config.sort"
+
+      assert unsorted =~ "config.filter"
+      refute unsorted =~ "config.sort"
+    end
+  end
+
+  describe "identities" do
+    test "the default addresses an update by primary key" do
+      assert context(Author, :destroy, %{}).identities == [:_primary_key]
+    end
+
+    test "an empty list drops the identity property and the payload key" do
+      kotlin = config(Author, :destroy, %{identities: []}, :destroy_author)
+
+      assert context(Author, :destroy, %{identities: []}).identities == []
+      refute kotlin =~ "val identity:"
+      refute payload(Author, :destroy, %{identities: []}, :destroy_author) =~ ~s|put("identity"|
+    end
+
+    test "a read never takes an identity, whatever the option says" do
+      assert context(Author, :read, %{identities: [:_primary_key]}).identities == []
+    end
+  end
+end

--- a/test/ash_kotlin_multiplatform/rpc/runner_rpc_action_options_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/runner_rpc_action_options_test.exs
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Rpc.RunnerRpcActionOptionsTest do
+  @moduledoc """
+  The `rpc_action` options that change what a request may carry, through
+  `Runner.run_action/3` — the only entry point a client has.
+
+  Issue #25: the shared core already honoured `get?`, applied `get_by`, read
+  `identities` and branched on `not_found_error?`, and the `kotlin_rpc` DSL
+  declared none of them. Every one of those branches was unreachable, so a
+  single-record read had no way to say which record it wanted: it ran as a list
+  read and returned the whole table.
+
+  `fetch_author` and `find_author` use the plain `:read` action, so what they
+  prove is the DSL wiring rather than Ash's own `get? true` — `get_author`
+  (action `:by_id`) is the action-level path and is covered elsewhere.
+  """
+  use ExUnit.Case, async: true
+
+  alias AshKotlinMultiplatform.Rpc.Runner
+
+  defp run(params), do: Runner.run_action(:ash_kotlin_multiplatform, params)
+
+  defp create_author(name, email) do
+    assert %{"success" => true, "data" => author} =
+             run(%{
+               "action" => "create_author",
+               "input" => %{"name" => name, "email" => email},
+               "fields" => ["id"]
+             })
+
+    author["id"]
+  end
+
+  defp error(response) do
+    assert %{"success" => false, "errors" => [error]} = response
+    error
+  end
+
+  defp unique_email, do: "author-#{System.unique_integer([:positive])}@example.com"
+
+  describe "get_by" do
+    test "selects the one record the client named" do
+      email = unique_email()
+      id = create_author("Ursula Le Guin", email)
+      _other = create_author("Octavia Butler", unique_email())
+
+      assert %{"success" => true, "data" => author} =
+               run(%{
+                 "action" => "fetch_author",
+                 "getBy" => %{"id" => id},
+                 "fields" => ["id", "name"]
+               })
+
+      assert author == %{"id" => id, "name" => "Ursula Le Guin"}
+    end
+
+    test "returns one record rather than a list" do
+      id = create_author("Ursula Le Guin", unique_email())
+
+      assert %{"success" => true, "data" => data} =
+               run(%{"action" => "fetch_author", "getBy" => %{"id" => id}, "fields" => ["id"]})
+
+      refute is_list(data)
+    end
+
+    test "names the fields that are missing" do
+      assert %{"type" => "missing_required_input", "field" => "id"} =
+               error(run(%{"action" => "fetch_author"}))
+    end
+
+    test "refuses a field the action did not configure" do
+      id = create_author("Ursula Le Guin", unique_email())
+
+      assert %{"type" => "unexpected_get_by_fields", "field" => "email"} =
+               error(
+                 run(%{
+                   "action" => "fetch_author",
+                   "getBy" => %{"id" => id, "email" => "someone@example.com"}
+                 })
+               )
+    end
+
+    # `Ash.Query.do_filter/2` reads a map operand as an operator expression, so
+    # an unchecked getBy value turns an exact lookup into an arbitrary
+    # predicate. The core rejects it; this proves the rejection reaches a client.
+    test "refuses a non-scalar value" do
+      assert %{"type" => "invalid_get_by"} =
+               error(run(%{"action" => "fetch_author", "getBy" => %{"id" => %{"gt" => "a"}}}))
+    end
+
+    test "refuses getBy on an action that configured none" do
+      assert %{"type" => "unexpected_get_by_fields"} =
+               error(run(%{"action" => "list_authors", "getBy" => %{"id" => "anything"}}))
+    end
+  end
+
+  describe "not_found_error?" do
+    test "true is an error when nothing matches" do
+      assert %{"type" => "not_found"} =
+               error(
+                 run(%{"action" => "fetch_author", "getBy" => %{"id" => Ash.UUID.generate()}})
+               )
+    end
+
+    test "false is a successful null when nothing matches" do
+      assert %{"success" => true, "data" => nil} =
+               run(%{"action" => "find_author", "getBy" => %{"email" => unique_email()}})
+    end
+
+    test "false still returns the record when one matches" do
+      email = unique_email()
+      create_author("Ursula Le Guin", email)
+
+      assert %{"success" => true, "data" => %{"name" => "Ursula Le Guin"}} =
+               run(%{
+                 "action" => "find_author",
+                 "getBy" => %{"email" => email},
+                 "fields" => ["name"]
+               })
+    end
+  end
+
+  describe "enable_filter? and enable_sort?" do
+    test "both are accepted by default" do
+      assert %{"success" => true} =
+               run(%{
+                 "action" => "list_books",
+                 "filter" => %{"title" => "Dune"},
+                 "sort" => "title"
+               })
+    end
+
+    # Rejected rather than dropped: a stale client that still sends `filter`
+    # would otherwise be handed the whole table with no way to know it asked for
+    # a subset.
+    test "enable_filter? false refuses a filter" do
+      assert %{"type" => "filter_not_supported"} =
+               error(
+                 run(%{"action" => "list_books_unfiltered", "filter" => %{"title" => "Dune"}})
+               )
+    end
+
+    test "enable_filter? false still accepts a sort" do
+      assert %{"success" => true} =
+               run(%{"action" => "list_books_unfiltered", "sort" => "title"})
+    end
+
+    test "enable_sort? false refuses a sort" do
+      assert %{"type" => "sort_not_supported"} =
+               error(run(%{"action" => "list_books_fixed_order", "sort" => "title"}))
+    end
+
+    test "enable_sort? false still accepts a filter" do
+      assert %{"success" => true} =
+               run(%{"action" => "list_books_fixed_order", "filter" => %{"title" => "Dune"}})
+    end
+  end
+
+  describe "identity on a read" do
+    # The core refuses it rather than dropping it, and the message names the
+    # replacement. Worth a test here because the runner has to route that error
+    # through the shared builder to keep the suggestion.
+    test "is refused and points at getBy" do
+      assert %{"type" => "identity_not_supported", "message" => message} =
+               error(run(%{"action" => "list_authors", "identity" => Ash.UUID.generate()}))
+
+      assert message =~ "getBy"
+    end
+  end
+end

--- a/test/ash_kotlin_multiplatform/rpc/verifiers/verify_identities_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/verifiers/verify_identities_test.exs
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2025 ash_kotlin_multiplatform contributors
+#
+# SPDX-License-Identifier: MIT
+
+defmodule AshKotlinMultiplatform.Test.VerifyIdentities.Article do
+  @moduledoc false
+  use Ash.Resource, domain: nil, extensions: [AshKotlinMultiplatform.Resource]
+
+  kotlin_multiplatform do
+    type_name("Article")
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :slug, :string, public?: true
+    attribute :draft_note, :string, public?: false
+  end
+
+  identities do
+    identity :unique_slug, [:slug], pre_check_with: nil
+  end
+
+  actions do
+    defaults [:read, :destroy]
+    default_accept [:slug]
+
+    update :rename do
+      accept [:slug]
+    end
+  end
+end
+
+defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentitiesTest do
+  @moduledoc """
+  `identities` and `get_by` both name a lookup key, and a wrong name is only
+  discoverable at runtime — as an Ash error the client author cannot trace back
+  to the DSL entry that caused it. Both were unreachable before #25 exposed the
+  options, so the `identities` half of this verifier could never fail.
+  """
+  use ExUnit.Case, async: true
+
+  import Spark.Test
+
+  alias AshKotlinMultiplatform.Test.VerifyIdentities.Article
+
+  describe "identities" do
+    test "accepts an identity defined on the resource" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.NamedIdentityDomain do
+          @moduledoc false
+          use Ash.Domain,
+            extensions: [AshKotlinMultiplatform.Rpc],
+            validate_config_inclusion?: false
+
+          resources do
+            resource Article
+          end
+
+          kotlin_rpc do
+            resource Article do
+              rpc_action :rename_article, :rename do
+                identities([:unique_slug])
+              end
+            end
+          end
+        end
+      end
+    end
+
+    test "rejects an identity the resource does not define" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.UnknownIdentityDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource Article
+            end
+
+            kotlin_rpc do
+              resource Article do
+                rpc_action :rename_article, :rename do
+                  identities([:unique_title])
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "Identity not found"
+      assert error.message =~ "unique_title"
+      assert error.message =~ "unique_slug"
+    end
+  end
+
+  describe "get_by" do
+    test "accepts a public attribute" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.GetByAttributeDomain do
+          @moduledoc false
+          use Ash.Domain,
+            extensions: [AshKotlinMultiplatform.Rpc],
+            validate_config_inclusion?: false
+
+          resources do
+            resource Article
+          end
+
+          kotlin_rpc do
+            resource Article do
+              rpc_action :get_article, :read do
+                get_by [:slug]
+              end
+            end
+          end
+        end
+      end
+    end
+
+    # The generated GetBy data class takes its Kotlin type from the attribute,
+    # so a name that is not one has no type to emit.
+    test "rejects a field that is not a public attribute" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.GetByPrivateDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource Article
+            end
+
+            kotlin_rpc do
+              resource Article do
+                rpc_action :get_article, :read do
+                  get_by [:draft_note]
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "get_by field is not a public attribute"
+      assert error.message =~ "draft_note"
+      assert error.message =~ "slug"
+    end
+  end
+end

--- a/test/fixtures/kotlin_compile/roundtrip/Roundtrip.kt
+++ b/test/fixtures/kotlin_compile/roundtrip/Roundtrip.kt
@@ -297,6 +297,73 @@ private fun typedMetadataEnvelopeReadsTheBareRecord(): String {
     return "data.name=${envelope.data.name} metadata=${envelope.metadata}"
 }
 
+// #25: the rpc_action options the shared core already honoured and the DSL
+// never declared. Every shape below is new to the wire, because a get? read had
+// no way to say which record it wanted and so ran as a list read.
+
+// The lookup class the config declares is what puts the key on the wire, and
+// the server accepts exactly one spelling of it. The fixture's `get_by_hit` was
+// produced by sending this object, so if @SerialName drifted the key here would
+// stop matching what the server answered to.
+private fun getByEncodesTheKeyTheServerReads(): String {
+    val sent = """{"id":"11111111-1111-1111-1111-111111111111"}"""
+    val getBy = ashRpcJson.decodeFromString<FetchAuthorGetBy>(sent)
+
+    expect("re-encoded", ashRpcJson.encodeToString(getBy), sent)
+
+    return "re-encoded unchanged: $sent"
+}
+
+// A get_by read returns the one record, not a list. Decoding it as
+// RpcResult<Author> is the measurement: before #25 this action answered with
+// the whole table, which this type cannot read at all.
+private fun getByHitDecodesOneRecord(): String {
+    val author = typed<Author>("get_by_hit").data!!
+
+    expect("name", author.name, "Typed One")
+    expect("data is an object", response("get_by_hit").jsonObject["data"] is JsonObject, true)
+
+    return "name=${author.name}"
+}
+
+// not_found_error? false: a successful response whose data is null — a
+// different shape from the not-found error `typed_get_miss` carries.
+private fun notFoundErrorFalseDecodesANull(): String {
+    val result = typed<Author>("get_by_null")
+
+    expect("success", result.success, true)
+    expect("data", result.data, null)
+    expect("errors", result.errors, null)
+
+    return "success=${result.success} data=${result.data}"
+}
+
+// The getBy checks reach the client as ordinary errors, so the generated error
+// class has to read them. `field` names the offending key.
+private fun getByValidationErrorsDecode(): String {
+    val missing = typed<Author>("get_by_missing_field").errors!!.single()
+    val unexpected = typed<Author>("get_by_unexpected_field").errors!!.single()
+
+    expect("missing.shortMessage", missing.shortMessage, "Missing required getBy fields")
+    expect("unexpected.type", unexpected.type, "unexpected_get_by_fields")
+
+    return "missing=${missing.type} unexpected=${unexpected.type}"
+}
+
+// enable_filter? / enable_sort? false refuse the parameter rather than dropping
+// it. The generated config for these actions declares no such property, so only
+// a stale client can produce these — and it has to be able to read the answer.
+private fun refusedReadParametersDecode(): String {
+    val filter = typed<AshPage<Book>>("filter_refused").errors!!.single()
+    val sort = typed<AshPage<Book>>("sort_refused").errors!!.single()
+
+    expect("filter.type", filter.type, "filter_not_supported")
+    expect("filter.shortMessage", filter.shortMessage, "Filter not supported")
+    expect("sort.type", sort.type, "sort_not_supported")
+
+    return "filter=${filter.type} sort=${sort.type}"
+}
+
 fun main() {
     check("#51 populated untyped map via dataAs()", ::populatedUntypedMap)
     check("#51 untyped map keeps number literals", ::untypedMapKeepsNumberLiterals)
@@ -316,6 +383,11 @@ fun main() {
     check("#22 destroy decodes the destroyed record", ::typedDestroyDecodes)
     check("#22 metadata envelope decodes into AshMetadata<Event, RegisterEventMetadata>", ::typedMetadataEnvelopeDecodes)
     check("#22 the same envelope reads the bare record", ::typedMetadataEnvelopeReadsTheBareRecord)
+    check("#25 getBy encodes the key the server reads", ::getByEncodesTheKeyTheServerReads)
+    check("#25 a get_by read decodes one record, not a list", ::getByHitDecodesOneRecord)
+    check("#25 not_found_error? false decodes a null", ::notFoundErrorFalseDecodesANull)
+    check("#25 getBy validation errors decode", ::getByValidationErrorsDecode)
+    check("#25 a refused filter or sort decodes", ::refusedReadParametersDecode)
 
     if (failures > 0) {
         println("$failures round-trip check(s) failed")

--- a/test/support/mix/tasks/ash_kotlin_multiplatform.gen_roundtrip_fixture.ex
+++ b/test/support/mix/tasks/ash_kotlin_multiplatform.gen_roundtrip_fixture.ex
@@ -48,19 +48,24 @@ defmodule Mix.Tasks.AshKotlinMultiplatform.GenRoundtripFixture do
     # author checks count rows, so the order they run in is part of the fixture.
     # `sparse_fieldset` asserts on a single author and must go before the typed
     # entries add more.
-    responses =
-      [
-        {"populated_untyped_map", populated_untyped_map()},
-        {"date_fields", date_fields()},
-        {"action_metadata", action_metadata()},
-        {"metadata_narrowed_away", metadata_narrowed_away()},
-        {"sparse_fieldset", sparse_fieldset()},
-        {"error", error()},
-        {"validation_valid", validation_valid()},
-        {"validation_invalid", validation_invalid()}
-      ]
-      |> Kernel.++(typed_results())
-      |> Map.new()
+    base = [
+      {"populated_untyped_map", populated_untyped_map()},
+      {"date_fields", date_fields()},
+      {"action_metadata", action_metadata()},
+      {"metadata_narrowed_away", metadata_narrowed_away()},
+      {"sparse_fieldset", sparse_fieldset()},
+      {"error", error()},
+      {"validation_valid", validation_valid()},
+      {"validation_invalid", validation_invalid()}
+    ]
+
+    # Bound in three steps rather than piped, so the order these run in is the
+    # order they are written: `sparse_fieldset` counts authors, and the typed
+    # entries create three more.
+    typed = typed_results()
+    get_by = get_by_results(typed)
+
+    responses = Map.new(base ++ typed ++ get_by)
 
     json = Phoenix.json_library().encode!(responses)
 
@@ -159,6 +164,30 @@ defmodule Mix.Tasks.AshKotlinMultiplatform.GenRoundtripFixture do
          "input" => %{"id" => "00000000-0000-0000-0000-000000000000"}
        })},
       {"typed_destroy", call(%{"action" => "destroy_author", "identity" => id(doomed)})}
+    ]
+  end
+
+  # The `rpc_action` options of #25. Each entry is a response the client's own
+  # config class has to produce or read, and every one of these branches was
+  # unreachable before the DSL declared the options — a `get?` read had no way
+  # to say which record it wanted, so it ran as a list read.
+  #
+  # Reuses the author `typed_results/0` already created rather than creating
+  # another: `typed_list` counts rows, and it runs first.
+  defp get_by_results(typed) do
+    {"typed_create", created} = Enum.find(typed, &match?({"typed_create", _}, &1))
+    author_id = id(created)
+
+    [
+      {"get_by_hit", call(%{"action" => "fetch_author", "getBy" => %{"id" => author_id}})},
+      {"get_by_null",
+       call(%{"action" => "find_author", "getBy" => %{"email" => "nobody@e.com"}})},
+      {"get_by_missing_field", call(%{"action" => "fetch_author"})},
+      {"get_by_unexpected_field",
+       call(%{"action" => "fetch_author", "getBy" => %{"id" => author_id, "email" => "x@e.com"}})},
+      {"filter_refused",
+       call(%{"action" => "list_books_unfiltered", "filter" => %{"title" => "Dune"}})},
+      {"sort_refused", call(%{"action" => "list_books_fixed_order", "sort" => "title"})}
     ]
   end
 

--- a/test/support/resources/author.ex
+++ b/test/support/resources/author.ex
@@ -70,10 +70,11 @@ defmodule AshKotlinMultiplatform.Test.Author do
       accept [:name, :email]
     end
 
-    # `get? true` is the only way an action reaches the get branch of
-    # `FunctionCore.determine_return_type/1`: the `kotlin_rpc` DSL has no `get?`
-    # or `get_by` option, so `ConfigBuilder.get_action_context/3` can only read
-    # it off the Ash action.
+    # An Ash-level `get? true`, which `ConfigBuilder.get_action_context/3` reads
+    # off the action itself. The `kotlin_rpc` DSL reaches the same branch through
+    # its own `get?` and `get_by` options (#25), and the domain's `fetch_author`
+    # covers that path; both need covering because they arrive from different
+    # places.
     read :by_id do
       get? true
 

--- a/test/support/test_domain.ex
+++ b/test/support/test_domain.ex
@@ -31,11 +31,34 @@ defmodule AshKotlinMultiplatform.Test.Domain do
       rpc_action :destroy_author, :destroy
       rpc_action :get_author, :by_id
       rpc_action :keyset_authors, :keyset_paged
+
+      # The DSL's own single-record options, over the plain `:read` action that
+      # knows nothing about them — so what is under test is the wiring, not
+      # Ash's `get? true`, which `get_author` above already covers.
+      rpc_action :fetch_author, :read do
+        get_by [:id]
+      end
+
+      # The other half of not-found: a null result rather than an error.
+      rpc_action :find_author, :read do
+        get_by [:email]
+        not_found_error? false
+      end
     end
 
     resource AshKotlinMultiplatform.Test.Book do
       rpc_action :list_books, :read
       rpc_action :create_book, :create
+
+      # Each of the two read-surface switches on its own, so a test can tell
+      # which one dropped which parameter.
+      rpc_action :list_books_fixed_order, :read do
+        enable_sort? false
+      end
+
+      rpc_action :list_books_unfiltered, :read do
+        enable_filter? false
+      end
     end
 
     resource AshKotlinMultiplatform.Test.Event do


### PR DESCRIPTION
Six of the `rpc_action` options upstream has and this DSL did not. Four of them
were already implemented in the shared core and simply never settable here:
`AshIntrospection.Rpc.Pipeline` branches on `get?`, applies `get_by`, reads
`identities` and reads `not_found_error?` off the config. Every one of those
branches was dead, so a "get" read had no way to say which record it wanted —
it ran as a list read and answered with the whole table.

Closes #25 for the options that work against `ash_introspection ~> 0.3`.
`allowed_loads`/`denied_loads` are deferred — see below.

## What landed

| Option | Default | Effect |
| --- | --- | --- |
| `get?` | `false` | Read returns one record or nothing. `data` becomes the resource, not `AshPage<Resource>`; `filter`, `sort` and `page` leave the config class |
| `get_by` | `[]` | Fields the client sends to select that record. Implies `get?` |
| `not_found_error?` | `true` | A `get?` read matching nothing is an error, or a successful `null` |
| `identities` | `[:_primary_key]` | Identities an update or destroy may be addressed by. `[]` = no identity |
| `enable_filter?` | `true` | Whether the client may send `filter` on a list read |
| `enable_sort?` | `true` | Whether the client may send `sort` on a list read |

Every default is the behaviour the client had before the option existed, so an
`rpc_action` that sets none of them is unchanged. Nothing previously valid is
rejected.

### `get_by` generates a typed lookup class

```kotlin
@Serializable
data class FetchAuthorGetBy(
    val id: String
)

data class FetchAuthorConfig(
    val getBy: FetchAuthorGetBy,
    val fields: List<Any> = emptyList(),
    val headers: Map<String, String> = emptyMap()
)

suspend fun fetchAuthor(...): RpcResult<Author>
```

Not a `Map<String, JsonElement>`: the server requires exactly the configured
fields and refuses anything else, so a hand-assembled map would fail at runtime
where the compiler could have said so. A missing field would widen the lookup
into a `MultipleResults` naming nothing the caller can act on; an extra field
reaches `Ash.Query.do_filter/2`, which reads a map operand as an operator
expression, turning an exact lookup into an arbitrary predicate.

### `enable_filter?`/`enable_sort?` reject rather than drop

The parameter leaves the generated config class, and the server refuses a
request that carries it anyway. Dropping it silently would hand a stale client
the whole table with no way to know it asked for a subset — the same reasoning
the core applied to `identity` on reads.

### These are not authorization

Said in the DSL docs, the README and the CHANGELOG, because someone will
otherwise reach for `enable_filter? false` as a security control. They shape an
action's **API surface**. Ash policies run on every request regardless of what
the DSL exposes, and narrowing the surface here neither adds nor removes a
check.

## Also fixed

`Rpc.Pipeline.build_config/0` wired the pipeline's `not_found_error?` to
`AshKotlinMultiplatform.warn_on_missing_rpc_config?/0` — a codegen-time
warning switch. Setting `warn_on_missing_rpc_config: false` to quiet codegen
also turned every runtime not-found into a successful `null`. It is now
per-action.

The `identity`-on-a-read refusal from the core reached clients as
`inspect/1` output; it now goes through the shared `ErrorBuilder`, so the
message keeps its suggestion to use `getBy`.

The README's DSL example named `expose_metadata`, which is not an option. The
real one is `show_metadata`.

## Deferred: `allowed_loads` / `denied_loads`

Not in this PR. They need `ash_introspection` 0.4.0's `:load_restrictions`
config key, and this repo requires `~> 0.3` — deliberately left alone.

The bump is breaking and needs its own decision: **0.4.0 rejects `identity` on
read actions**, and the generated Swift client emits `identity: id` on every
`get?` read (`swift/codegen.ex`), so bumping turns every Swift `getX(id:)` into
a hard error. That is gated on #31 — whether the Swift generator is fixed or
flagged experimental — which is a maintainer call, not something to settle
inside a feature PR.

One thing found while checking: the **locked 0.3.0 already rejects `identity`
on reads.** `deps/ash_introspection/lib/ash_introspection/rpc/pipeline.ex`
returns `{:error, {:identity_not_supported, ...}}` for a read carrying an
identity, and its CHANGELOG files that change under `[Unreleased]` rather than
under `[0.3.0]`. So that half of the #31 breakage is live today, not pending
the bump. A test in this PR pins it.

## Test plan

All three CI gates, run locally before pushing.

**Elixir** — `mix compile --warnings-as-errors` clean, `mix test` **223 tests,
0 failures** (was 192 on `main` at `54388f2`), `mix hex.audit` no retired
packages, `mix deps.audit` no vulnerabilities.

31 new tests:

- `runner_rpc_action_options_test.exs` (15) — every option through
  `Runner.run_action/3`, the only entry point a client has. A `get_by` read
  returns one record and not a list; `not_found_error?` both ways; missing,
  unexpected and non-scalar `getBy`; each read switch refusing its own
  parameter and leaving the other alone; `identity` on a read.
- `rpc_action_options_codegen_test.exs` (12) — the config class and the payload
  builder asserted together, because when the two disagreed the emitted Kotlin
  referenced a property that was never declared.
- `verify_identities_test.exs` (4) — the compile-time checks. Its `identities`
  half could never fail before, for want of a way to set the option.

**Kotlin compile gate** — `gradle compileKotlin`, BUILD SUCCESSFUL, both
`:java-time` and `:kotlinx-datetime`.

**Round-trip decode gate** — `gradle run`, BUILD SUCCESSFUL, 46 PASS / 0 FAIL
(23 checks × 2 subprojects). Five are new, and every one is a wire shape that
did not exist before, produced by running the action rather than describing it:

```
PASS #25 getBy encodes the key the server reads -> re-encoded unchanged: {"id":"11111111-1111-1111-1111-111111111111"}
PASS #25 a get_by read decodes one record, not a list -> name=Typed One
PASS #25 not_found_error? false decodes a null -> success=true data=null
PASS #25 getBy validation errors decode -> missing=missing_required_input unexpected=unexpected_get_by_fields
PASS #25 a refused filter or sort decodes -> filter=filter_not_supported sort=sort_not_supported
```

`get_by_hit` is an object where a list used to be — `RpcResult<Author>` cannot
read the old response at all. The encoding check re-encodes a
`FetchAuthorGetBy` and compares it to the literal the server answered to, which
is what ties the emitted `@SerialName` to the key `Runner` reads.

One fixture bug fixed on the way: the entries run against one shared ETS table
and `sparse_fieldset` counts rows, so binding the typed creates before it broke
that count. Entries are now bound in written order.

## Not verified

- No Ash policies are declared on the test resources, so "policies still run"
  is stated from Ash's documented behaviour, not measured here.
- `identities` with a **named** identity is covered by the compile-time
  verifier and the codegen context, not by a runtime update through a named
  identity — no test resource has both an identity and a data layer.
- `enable_filter?`/`enable_sort?` on a **channel** call: the channel client is
  generic (`channel.call(action, input, fields)`) and has no per-action config
  class, so it is unaffected by design, but no test asserts that.
