### PR TITLE
docs: sync the source of truth with #25

### DIFF
--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -28,10 +28,10 @@ between versions.
 
 | Page | Answers | Status |
 | ---- | ------- | ------ |
-| [architecture.md](architecture.md) | How a resource becomes Kotlin and Swift, and what runs at request time | Current as of #22 |
-| [decisions.md](decisions.md) | The choices that still shape the code, and what each cost | Current as of #22 |
-| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | Current as of #22 |
-| [roadmap.md](roadmap.md) | What shipped, what is in flight, what is next, what was refused | Current as of #22 |
+| [architecture.md](architecture.md) | How a resource becomes Kotlin and Swift, and what runs at request time | Current as of #25 |
+| [decisions.md](decisions.md) | The choices that still shape the code, and what each cost | Current as of #25 |
+| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | Current as of #25 |
+| [roadmap.md](roadmap.md) | What shipped, what is in flight, what is next, what was refused | Current as of #25 |
 
 ## Keeping it current
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ flowchart TD
     task["Mix.Tasks.AshKotlinMultiplatform.Codegen"] --> cg["Rpc.Codegen.generate_kotlin_code/2"]
 
     cg --> coll["Rpc.Codegen.RpcConfigCollector<br/>reads Rpc.Info off each domain"]
-    cg --> vc["VerifierChecker<br/>VerifyIdentities, VerifyActionTypes,<br/>VerifyFieldNames, VerifyUniqueTypeNames"]
+    cg --> vc["VerifierChecker<br/>VerifyIdentities (identities and get_by),<br/>VerifyActionTypes,<br/>VerifyFieldNames, VerifyUniqueTypeNames"]
 
     coll --> tuples["{resource, action, rpc_action}"]
 
@@ -120,6 +120,24 @@ into the signature. Ktor resolves `.body()` from that declared type, so this
 one string is what makes a response decode into a resource class rather than
 a `JsonElement` (#22).
 
+`ConfigBuilder.get_action_context/3` turns the `rpc_action` options into the
+context that both `ConfigBuilder` and `PayloadBuilder` read, and the two have
+to agree key for key (#25). `get_by` adds a `@Serializable` lookup class —
+`FetchAuthorGetBy` for the test domain's `rpc_action :fetch_author` — and a
+matching `getBy` line in the payload. `supports_filtering` and
+`supports_sorting` are separate context keys, so `enable_filter? false` leaves
+`sort` alone. When the two builders disagreed, the emitted Kotlin referenced a
+property that was never declared, which is why
+`test/ash_kotlin_multiplatform/rpc/codegen/rpc_action_options_codegen_test.exs`
+asserts the config class and the payload together.
+
+`VerifyIdentities` checks both ways an `rpc_action` can name a record. On an
+update or destroy, every entry in `identities` must be `:_primary_key` or an
+identity on the resource; on a read, every field in `get_by` must be a public
+attribute, because `ConfigBuilder` takes the lookup class's Kotlin type from
+that attribute. Before #25 the DSL had no way to set `identities`, so the
+verifier could never fail.
+
 Two things about `PhoenixChannel` that the box does not show. It is
 **static**: it takes no resource and no action, so the same text is emitted
 for every application, which is issue #35. And it is the only generated code
@@ -142,10 +160,11 @@ sequenceDiagram
     participant Pipe as Rpc.Pipeline
     participant Ash as Ash domain
 
-    App->>Ctl: POST /rpc/run {action, input, fields}
+    App->>Ctl: POST /rpc/run {action, input, fields, getBy}
     Ctl->>Run: run_action(otp_app, params, actor:, tenant:)
+    Note over Run: rpc_action options, before the pipeline (issue 25) —<br/>refuse a filter or sort the DSL switched off,<br/>require exactly the configured getBy fields,<br/>set the Ash action's get? from get? or get_by
     Run->>Pipe: parse_request, execute, format_output
-    Pipe->>Ash: Ash.read / create / update / destroy
+    Pipe->>Ash: Ash.read_one when get?, else Ash.read / create / update / destroy
     Ash-->>Pipe: records
     Pipe-->>Run: field-selected map
     Run-->>Ctl: %{success: true, data: ...}
@@ -157,6 +176,23 @@ sequenceDiagram
     Run-->>Ch: result map
     Ch-->>App: phx_reply
 ```
+
+The two parameter checks in the note run in `Rpc.Runner.build_request/8`,
+before anything reaches the shared core, and each answers with an ordinary
+error response rather than a raise. The third is applied a level up, in
+`Rpc.Runner.execute_action/7`, and it works differently: a DSL-level `get?`
+reaches the core as the *Ash* action's own `get?` field, because
+`AshIntrospection.Rpc.Pipeline.execute_read_action/3` branches on that to pick
+`Ash.read_one/1` over `Ash.read/1` and builds the query from `action.name`.
+Overriding that one field selects the single-record path and nothing else.
+
+`Rpc.Pipeline.build_config/1` is the per-action half of the pipeline config,
+and `not_found_error?` is the only key that varies by action. `build_config/0`
+used to read that key from
+`AshKotlinMultiplatform.warn_on_missing_rpc_config?/0`, a codegen-time warning
+switch, so a project that silenced codegen warnings also turned every
+not-found into a successful `null`. The field selector and the error builder
+still call `build_config/0`; neither reads the key.
 
 ## 5. The Phoenix channel wire format
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -234,3 +234,62 @@ envelope, which misreads a resource that publishes attributes with both of
 those names when the metadata has been narrowed away. Nothing else produces
 that pair. Both are decoded from real `Runner` responses by the round-trip
 gate, including the narrowed-away case.
+
+## 2026-09-11 — The DSL's `get?` reaches the core as the Ash action's `get?`
+
+`Rpc.Runner.execute_action/7` copies the `rpc_action`'s `get?` onto the
+introspected `Ash.Resource.Actions.Read` struct before the pipeline sees it
+(#25). `get_by` implies `get?`, so naming the lookup fields is the whole
+statement and no config can ask for a key and a list in the same breath.
+
+Why: `AshIntrospection.Rpc.Pipeline.execute_read_action/3` reads `action.get?`
+for one thing only — choosing `Ash.read_one/1` over `Ash.read/1` — and
+builds the query from `action.name`. Setting that one field selects the
+single-record path and changes nothing else. The alternative was a new config
+key in the shared core, which is a release of `ash_introspection` before this
+library could ship the option at all.
+
+Cost: the runner writes to a struct Ash owns. If the core ever reads `get?`
+for something besides that branch, the override does more than this library
+intends, with no signal. `mix.exs` pins `ash_introspection ~> 0.3`, so that is
+the line to re-read on a bump.
+
+## 2026-09-11 — A switched-off read parameter is refused, not dropped
+
+`enable_filter? false` and `enable_sort? false` remove the property from the
+generated config class *and* make `Rpc.Runner.check_read_surface/3` reject a
+request that sends it anyway (#25).
+
+Why: no current client can send the parameter, so only a stale one reaches
+this error — and dropping it in silence would hand that client the whole
+table with no way to know it had asked for a subset. The shared core already
+reasoned this way about `identity` on a read.
+
+These options shape an action's API surface. They are not authorization. Ash
+policies run on every request regardless of what the DSL exposes, and
+`enable_filter? false` hides no rows — it removes the client's ability to ask
+for fewer. The README and the `rpc_action` moduledoc both say so, because
+someone will otherwise reach for it as a security control.
+
+Cost: one error type per switched-off parameter, `filter_not_supported` and
+`sort_not_supported`, that every client has to be able to read. Both are
+decoded by the round-trip gate.
+
+## 2026-09-11 — `getBy` is a generated lookup class, not a map
+
+A `get_by` read gets its own `@Serializable` data class — `FetchAuthorGetBy`
+for the test domain's `rpc_action :fetch_author` — rather than the
+`Map<String, JsonElement>` the config's `filter` still uses.
+
+Why: the server requires exactly the configured fields and refuses anything
+else, so a client assembling that map by hand would learn at runtime what the
+compiler could have told it. A missing field widens the lookup into a
+`MultipleResults` naming nothing the caller can act on; an extra one reaches
+`Ash.Query.do_filter/2`, which reads a map operand as an operator expression
+and turns an exact lookup into an arbitrary predicate.
+
+Cost: one more generated class per `get_by` action, and a wire key two
+generators have to spell the same way. `@SerialName` carries the resource's
+own field name to match `InputTypes.generate_input_type/2`, and the round-trip
+check `#25 getBy encodes the key the server reads` re-encodes the class and
+compares it to the payload the fixture's hit was produced by.

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -76,6 +76,21 @@ declares only the v1 serializer.
 *Do:* nothing for the stock Phoenix socket, which offers both. A host that
 narrowed `serializer:` to v1 must add v2.
 
+### `get_by` on an action that is not a read fails only at runtime
+
+`VerifyIdentities` checks `get_by` on read actions only, and
+`ConfigBuilder.get_action_context/3` zeroes it for every other type. So
+`get_by [:id]` on a create, update or destroy compiles clean and generates a
+config class with no lookup field — and then `Rpc.Runner`'s `parse_get_by`,
+which runs on every action type, finds the configured field missing from the
+request and refuses the call. Every call to that action fails, and nothing
+said so at compile time.
+
+*Watch:* nothing. No test covers the combination.
+*Do:* extend the read branch of `VerifyIdentities` to reject a non-empty
+`get_by` on any action that is not a read, so the DSL entry breaks the build
+instead of the client.
+
 ### `main` is not formatter-clean
 
 `mix format --check-formatted` fails on ten files that predate the current
@@ -108,6 +123,20 @@ Central.
 dependency jars rather than committing a wrapper.
 
 ## Product
+
+### The rpc_action surface options read like authorization
+
+`get_by`, `enable_filter?` and `enable_sort?` narrow what an endpoint accepts,
+which is what a permission looks like from the outside. They are not one (#25).
+Ash policies run on every request regardless of what the DSL exposes, and
+`enable_filter? false` hides no rows — it removes the client's ability to ask
+for fewer, so the action answers with the whole table.
+
+*Watch:* the "not authorization" paragraph under the DSL example in the README,
+and the same words in the `rpc_action` moduledoc in
+`lib/ash_kotlin_multiplatform/rpc.ex`.
+*Do:* repeat that framing on every option added to this group, and answer an
+access question with a policy, never a DSL switch.
 
 ### The request half of the client is still untyped
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -32,6 +32,7 @@ afterwards.
 | 2026-09-09 | The generated Kotlin decodes the server's own responses (#24, PR #56) |
 | 2026-09-10 | One shared `Json`, `JsonElement` for untyped shapes, and a decode gate in CI (#51, #54, #58) |
 | 2026-09-11 | Typed results: every RPC function returns `RpcResult<T>` (#22) |
+| 2026-09-11 | Six `rpc_action` options the shared core already honoured: `get?`, `get_by`, `identities`, `not_found_error?`, `enable_filter?`, `enable_sort?` (#25, PR #66) |
 
 ## In progress
 


### PR DESCRIPTION
Syncs `docs/` with `main` after PR #66 (issue #25) merged as `30b3ced`, which
declared six `rpc_action` options the shared core already honoured.

Docs only. No code, no tests, no generated output changed.

What each page now says:

- **roadmap.md** — one shipped row for #25 naming all six options. Nothing
  removed: #25 was never listed under in progress or next.
- **architecture.md** — the request-path sequence diagram now shows the three
  checks `Rpc.Runner` runs before the shared core, and the generator diagram's
  verifier box says `VerifyIdentities` covers `identities` and `get_by`. New
  prose on what `ConfigBuilder` and `PayloadBuilder` have to agree on, and on
  `Rpc.Pipeline.build_config/1` being the per-action half.
- **risks.md** — two added. `get_by` on a create, update or destroy passes the
  verifier and then fails every call at runtime. And the surface options read
  like authorization when they are not. Nothing retired: #25 closes no risk
  already on the page.
- **decisions.md** — three dated entries: the runner overrides the Ash action's
  own `get?` rather than adding a key to `ash_introspection`; a switched-off
  `filter` or `sort` is refused, not dropped; `getBy` is a generated
  `@Serializable` class, not a map.
- **PROJECT.md** — page statuses moved from #22 to #25.

All four Mermaid diagrams render clean (headless Chrome, 0 syntax errors). The
new note in the sequence diagram says "issue 25", not "#25": Mermaid reads a
bare `#` as the start of an entity code and silently drops the rest of the note.
