### PR TITLE
Real Kotlin types for vector, money, ltree and ULID (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bulk-destroys with `return_records?: true`. Nothing had noticed, because
   `FunctionCore.determine_return_type/1` had no caller.
 
+- Four Ash types no longer reach Kotlin as an opaque `JsonElement`
+  ([#30](https://github.com/udin-io/ash_kotlin_multiplatform/issues/30)).
+  `Ash.Type.Vector` maps to `List<Double>`, `AshPostgres.Ltree` to
+  `List<String>`, `AshDoubleEntry.ULID` to `String`, and
+  `AshMoney.Types.Money` to `AshMoney`, a new `@Serializable` data class the
+  generator emits into every file with an `amount: String` and a
+  `currency: String`, because a field naming a class the file does not
+  declare does not compile. That shape is what ash_money sends: a decimal
+  string and a currency code.
+
+  A money, ltree or ULID field that a client unpacked from `JsonElement` by
+  hand now arrives typed; that call site has to change. Vectors are typed but
+  not yet transportable — a vector response still raises `Jason.EncodeError`
+  ([#71](https://github.com/udin-io/ash_kotlin_multiplatform/issues/71)).
+
 ### Added
 
 - Six `rpc_action` options, all additive — an `rpc_action` that sets none of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,3 +148,19 @@ nowhere to live. That is the shape (see `docs/decisions.md`), and it is where
 `Rpc.Codegen`, not looked up inside a generator: #52 fixed #44 by passing
 `ResourceSchemas.generate_data_class/2` the set of resources the same pass
 emits a class for. Follow that pattern.
+
+### The runner formats field names, not values
+
+`Rpc.Runner.execute_action/7` calls
+`AshIntrospection.Rpc.Pipeline.format_output/1`, which renames keys and stops
+there. Nothing in `lib/` calls `AshIntrospection.Rpc.ValueFormatter`, so the
+shared core's type-aware formatting — the clause that turns `%Ash.Vector{}`
+into a list of numbers, and everything beside it — never runs. A value whose
+in-memory form is not JSON-encodable therefore reaches the encoder raw and
+raises: measured 2026-09-11, a `:vector` attribute raises
+`Jason.EncodeError` on the packed binary (#71).
+
+So a new type needs both halves checked. A Kotlin type that reads the wire
+format proves nothing about whether this library can produce that wire
+format; run the action through `Runner` and encode the result before
+believing it.

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -28,10 +28,10 @@ between versions.
 
 | Page | Answers | Status |
 | ---- | ------- | ------ |
-| [architecture.md](architecture.md) | How a resource becomes Kotlin and Swift, and what runs at request time | Current as of #25 |
-| [decisions.md](decisions.md) | The choices that still shape the code, and what each cost | Current as of #25 |
-| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | Current as of #25 |
-| [roadmap.md](roadmap.md) | What shipped, what is in flight, what is next, what was refused | Current as of #25 |
+| [architecture.md](architecture.md) | How a resource becomes Kotlin and Swift, and what runs at request time | Current as of #30 |
+| [decisions.md](decisions.md) | The choices that still shape the code, and what each cost | Current as of #30 |
+| [risks.md](risks.md) | What could go wrong, what we watch, what we would do | Current as of #30 |
+| [roadmap.md](roadmap.md) | What shipped, what is in flight, what is next, what was refused | Current as of #30 |
 
 ## Keeping it current
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ flowchart TD
 
     coll --> tuples["{resource, action, rpc_action}"]
 
-    tuples --> static["KotlinStatic<br/>imports, type aliases, the shared ashRpcJson,<br/>HttpClient factory, AshRpcError, RpcResult&lt;T&gt;"]
+    tuples --> static["KotlinStatic<br/>imports, type aliases, AshMoney,<br/>the shared ashRpcJson,<br/>HttpClient factory, AshRpcError, RpcResult&lt;T&gt;"]
     tuples --> schemas["Codegen.ResourceSchemas<br/>data classes, enums,<br/>sealed unions, embedded"]
     tuples --> types["TypeGenerators.*<br/>InputTypes, MetadataTypes (+ AshMetadata&lt;T, M&gt;),<br/>PaginationTypes (AshPage&lt;T&gt;)"]
     tuples --> filters["Codegen.FilterTypes<br/>Codegen.TypedQueries"]
@@ -119,6 +119,13 @@ matters runs between them: `FunctionCore.determine_return_type/1` names the
 into the signature. Ktor resolves `.body()` from that declared type, so this
 one string is what makes a response decode into a resource class rather than
 a `JsonElement` (#22).
+
+`TypeMapper` and `KotlinStatic` are a pair wherever the mapper names a class
+rather than a built-in. `AshMoney.Types.Money` maps to `AshMoney`, and
+`KotlinStatic.generate_money_type/0` declares that class in every generated
+file — a field typed `AshMoney` in a file that declares none does not compile
+(#30). `Ash.Type.Vector`, `AshPostgres.Ltree` and `AshDoubleEntry.ULID` need no
+declaration: they map to `List<Double>`, `List<String>` and `String`.
 
 `ConfigBuilder.get_action_context/3` turns the `rpc_action` options into the
 context that both `ConfigBuilder` and `PayloadBuilder` read, and the two have

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -293,3 +293,33 @@ generators have to spell the same way. `@SerialName` carries the resource's
 own field name to match `InputTypes.generate_input_type/2`, and the round-trip
 check `#25 getBy encodes the key the server reads` re-encodes the class and
 compares it to the payload the fixture's hit was produced by.
+
+## 2026-09-11 — A shared `AshMoney` class, and no union for an ltree
+
+Four types left the unknown-type fallback in #30. Three map to a built-in:
+`Ash.Type.Vector` to `List<Double>`, `AshPostgres.Ltree` to `List<String>`,
+`AshDoubleEntry.ULID` to `String`. `AshMoney.Types.Money` maps to `AshMoney`,
+a `@Serializable data class` `KotlinStatic.generate_money_type/0` emits into
+every generated file.
+
+Why a class and not an alias: money is two values. `amount` is a decimal
+string and `currency` a code, which is what ash_money's `Jason.Encoder` sends
+and what `AshMoney.Types.Money.json_schema/1` documents. `amount` stays a
+`String` for the reason `Ash.Type.Decimal` does — reading a currency amount
+into a `Double` would round it.
+
+Why `AshMoney` and not upstream's `Money`: the generated file already prefixes
+its own shared classes `Ash` — `AshRpcError`, `AshPage`, `AshMetadata` —
+and a consumer's own `Money` class is likelier than a clash on that prefix.
+
+Why `List<String>` for an ltree under both `escape?` settings: upstream types
+the unescaped case `string | string[]`, because `AshPostgres.Ltree.cast_input/2`
+also accepts a dotted string. Kotlin has no untagged union, and the value is a
+list of segments in memory either way, so the output type is the same under
+both and a generated client always sends segments.
+
+Cost: `AshMoney` is emitted whether or not a consumer uses money, because the
+generator cannot see ash_money without depending on it. A Money field cannot
+be checked end to end here for the same reason — the round-trip gate has no
+money response to decode, so `client_server_contract_test.exs` holds the class
+to ash_money's documented shape instead.

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -28,6 +28,24 @@ resources, so a shape no test resource has is still unchecked, and the decode
 half only checks the responses the fixture carries. A new response shape
 needs a new check in `roundtrip/Roundtrip.kt`, or it is unwatched.
 
+### The shared core formats values by type, and this library never asks it to
+
+`Rpc.Runner.execute_action/7` formats a response with
+`AshIntrospection.Rpc.Pipeline.format_output/1`, which formats field names and
+nothing else. Nothing in `lib/` calls `AshIntrospection.Rpc.ValueFormatter`, so
+every value the shared core would format by type reaches the JSON encoder raw.
+Measured 2026-09-11: a `:vector` attribute arrives as `%Ash.Vector{}`'s packed
+binary and raises `Jason.EncodeError`, which is #71. The same path carries
+unions, typed maps and custom types with map storage.
+
+*Watch:* the round-trip gate, but only where the fixture goes — it carries no
+vector response, because the server cannot produce one.
+*Do:* fix #71 with a round-trip entry per shape. The type-aware entry point
+`Pipeline.format_output_with_request/3` is not a drop-in: it builds the
+`%{success:, data:}` envelope `Runner.build_success_response/1` already builds,
+and its `ValueFormatter.format/5` passes a list of records through untouched,
+so a list read would lose the field-name formatting it has today.
+
 ### Swift is generated and never compiled
 
 `Swift.Codegen` is 742 lines with two test files and no compiler anywhere in

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -33,6 +33,7 @@ afterwards.
 | 2026-09-10 | One shared `Json`, `JsonElement` for untyped shapes, and a decode gate in CI (#51, #54, #58) |
 | 2026-09-11 | Typed results: every RPC function returns `RpcResult<T>` (#22) |
 | 2026-09-11 | Six `rpc_action` options the shared core already honoured: `get?`, `get_by`, `identities`, `not_found_error?`, `enable_filter?`, `enable_sort?` (#25, PR #66) |
+| 2026-09-11 | Kotlin types for vector, money, ltree and ULID, plus the `AshMoney` class a money field needs (#30) |
 
 ## In progress
 
@@ -44,6 +45,7 @@ Ordered by what unblocks the most.
 
 | Issue | What | Why now |
 | ----- | ---- | ------- |
+| #71 | A vector response raises `Jason.EncodeError`: the runner never runs the shared core's type-aware output formatter | #30 named the Kotlin type; the server cannot send one yet |
 | #38 | Make `main` formatter-clean and put the check in CI | One mechanical commit; unblocks review signal |
 | #65, #53 | Typed `filter` and `page` in the request config | The response is typed now; the request still takes untyped maps, so `FilterTypes` is dead code |
 | #48, #53 | The runner mangles unconstrained map keys; FilterTypes emits unpublished resources | Both leak shapes the client cannot use |

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -166,6 +166,20 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   # UUID types - use String for KMP compatibility
   defp map_type(Ash.Type.UUID, _constraints), do: "String"
 
+  # A vector belongs on the wire as a JSON array of numbers, never as the packed
+  # binary `%Ash.Vector{}` carries. `AshIntrospection.Rpc.ValueFormatter` expands
+  # it with `Ash.Vector.to_list/1`
+  # (`deps/ash_introspection/lib/ash_introspection/rpc/value_formatter.ex:206`),
+  # but `Rpc.Runner` never calls that formatter, so a vector *response* still
+  # raises `Jason.EncodeError` today — #71. This type already serves a request
+  # payload, because `Ash.Type.Vector.cast_input/2` accepts a list, and it is
+  # what the array decodes into once #71 lands.
+  #
+  # `Double` and not `Float`, because kotlinx-serialization reads a JSON number
+  # into whichever the field declares and `Double` cannot lose a value the
+  # encoder wrote (#30).
+  defp map_type(Ash.Type.Vector, _constraints), do: "List<Double>"
+
   # Date/time types
   defp map_type(Ash.Type.Date, _constraints) do
     case AshKotlinMultiplatform.datetime_library() do

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -278,6 +278,12 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
   # absent: an atom needs no module behind it. Ported from ash_typescript
   # 3f02631 (#30).
   #
+  # `AshMoney` is the shared class
+  # `AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic.generate_money_type/0`
+  # declares. Naming a class the generated file does not declare is a compile
+  # error, so the two move together.
+  defp map_type(AshMoney.Types.Money, _constraints), do: "AshMoney"
+
   # An ltree value is a list of segment strings in memory, whatever `escape?`
   # says: `AshPostgres.Ltree.cast_input/2` splits a dotted string into one
   # (`lib/types/ltree.ex`). So the output type is `List<String>` under both

--- a/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/type_mapper.ex
@@ -272,6 +272,25 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapper do
     end
   end
 
+  # Third-party Ash types this library does not depend on. They implement no
+  # `interop_field_names/0`, so the branches below would send each one to the
+  # unknown-type fallback. Naming the modules costs nothing when the package is
+  # absent: an atom needs no module behind it. Ported from ash_typescript
+  # 3f02631 (#30).
+  #
+  # An ltree value is a list of segment strings in memory, whatever `escape?`
+  # says: `AshPostgres.Ltree.cast_input/2` splits a dotted string into one
+  # (`lib/types/ltree.ex`). So the output type is `List<String>` under both
+  # settings. Upstream types the unescaped case `string | string[]` to accept
+  # the dotted form on input; Kotlin has no untagged union, and a typed client
+  # that always sends segments is the honest half of that.
+  defp map_type(AshPostgres.Ltree, _constraints), do: "List<String>"
+
+  # A ULID is a 26-character Crockford Base32 string
+  # (`ash_double_entry/lib/ulid.ex` `cast_input/2`), the same decision
+  # `Ash.Type.UUID` takes above.
+  defp map_type(AshDoubleEntry.ULID, _constraints), do: "String"
+
   # Check if it's an embedded resource
   defp map_type(type, constraints) when is_atom(type) do
     cond do

--- a/lib/ash_kotlin_multiplatform/rpc/codegen.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen.ex
@@ -110,6 +110,7 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen do
         generate_header(package_name),
         KotlinStatic.generate_imports(opts),
         KotlinStatic.generate_type_aliases(),
+        KotlinStatic.generate_money_type(),
         KotlinStatic.generate_shared_json(),
         KotlinStatic.generate_http_client_factory(),
         KotlinStatic.generate_error_types(),

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/kotlin_static.ex
@@ -217,6 +217,35 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic do
   end
 
   @doc """
+  Generates the shared class a money value decodes into.
+
+  `AshKotlinMultiplatform.Codegen.TypeMapper` types `AshMoney.Types.Money` as
+  `AshMoney`, and a field typed `AshMoney` in a file that declares no such class
+  does not compile — so the mapping and this declaration are one decision (#30).
+
+  Emitted for every application, like the type aliases above, because the
+  generator cannot tell whether a consumer's resources use money without
+  ash_money as a dependency, and an unused class costs a consumer nothing.
+
+  The two fields are what ash_money puts on the wire: its `Jason.Encoder` sends
+  `currency` and `amount` and nothing else, and `AshMoney.Types.Money`'s
+  `json_schema/1` documents both as strings. `amount` is a `String` for the
+  reason `Ash.Type.Decimal` is one — `Decimal`'s JSON encoder writes a quoted
+  decimal string, and reading it into a `Double` would round a currency amount.
+  """
+  def generate_money_type do
+    """
+    // A money value, as ash_money sends it: a decimal string and a currency
+    // code (#30).
+    @Serializable
+    data class AshMoney(
+        val amount: String,
+        val currency: String
+    )
+    """
+  end
+
+  @doc """
   Generates the RPC error types.
   """
   # `shortMessage` carries no `@SerialName`. Every error map `Rpc.Runner` builds

--- a/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
@@ -111,6 +111,20 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
     end
   end
 
+  # #30. Each of these reached the unknown-type fallback, so the field arrived in
+  # a generated client as an opaque `JsonElement` the caller unpacked by hand.
+  describe "types that fell through to the unknown-type fallback" do
+    test "maps Ash.Type.Vector to a list of doubles" do
+      attr = %{type: Ash.Type.Vector, constraints: [dimensions: 3], allow_nil?: true}
+      assert TypeMapper.get_kotlin_type(attr) == "List<Double>?"
+    end
+
+    test "maps an array of vectors" do
+      assert TypeMapper.get_kotlin_type_for_type({:array, Ash.Type.Vector}) ==
+               "List<List<Double>>"
+    end
+  end
+
   describe "is_enum_type?/2" do
     test "is true for an atom constrained to a list of values" do
       assert TypeMapper.is_enum_type?(Ash.Type.Atom, one_of: [:a, :b])

--- a/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
@@ -123,6 +123,20 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
       assert TypeMapper.get_kotlin_type_for_type({:array, Ash.Type.Vector}) ==
                "List<List<Double>>"
     end
+
+    # The two below name modules this library does not depend on. Passing the
+    # bare module atom is exactly what the generator does with a type it cannot
+    # resolve, so it exercises the clauses without adding the packages.
+    test "maps AshPostgres.Ltree to segment strings under both escape? settings" do
+      assert TypeMapper.get_kotlin_type_for_type(AshPostgres.Ltree) == "List<String>"
+
+      assert TypeMapper.get_kotlin_type_for_type(AshPostgres.Ltree, escape?: true) ==
+               "List<String>"
+    end
+
+    test "maps AshDoubleEntry.ULID to String" do
+      assert TypeMapper.get_kotlin_type_for_type(AshDoubleEntry.ULID) == "String"
+    end
   end
 
   describe "is_enum_type?/2" do

--- a/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/codegen/type_mapper_test.exs
@@ -124,9 +124,13 @@ defmodule AshKotlinMultiplatform.Codegen.TypeMapperTest do
                "List<List<Double>>"
     end
 
-    # The two below name modules this library does not depend on. Passing the
+    # The three below name modules this library does not depend on. Passing the
     # bare module atom is exactly what the generator does with a type it cannot
     # resolve, so it exercises the clauses without adding the packages.
+    test "maps AshMoney.Types.Money to the shared AshMoney class" do
+      assert TypeMapper.get_kotlin_type_for_type(AshMoney.Types.Money) == "AshMoney"
+    end
+
     test "maps AshPostgres.Ltree to segment strings under both escape? settings" do
       assert TypeMapper.get_kotlin_type_for_type(AshPostgres.Ltree) == "List<String>"
 

--- a/test/ash_kotlin_multiplatform/rpc/client_server_contract_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/client_server_contract_test.exs
@@ -19,6 +19,7 @@ defmodule AshKotlinMultiplatform.Rpc.ClientServerContractTest do
   use ExUnit.Case, async: true
 
   alias AshKotlinMultiplatform.Codegen.ResourceSchemas
+  alias AshKotlinMultiplatform.Codegen.TypeMapper
   alias AshKotlinMultiplatform.Rpc.Codegen.KotlinStatic
   alias AshKotlinMultiplatform.Rpc.Runner
   alias AshKotlinMultiplatform.Test.Author
@@ -111,6 +112,25 @@ defmodule AshKotlinMultiplatform.Rpc.ClientServerContractTest do
       assert %{"success" => true, "data" => data} = response
       refute Map.has_key?(response, "metadata")
       assert data["metadata"] == %{"registeredAt" => ~U[2026-01-01 00:00:00Z]}
+    end
+  end
+
+  # ash_money is not a dependency, so no `Runner` response here can carry a
+  # money value and the usual pairing is impossible. The contract comes from
+  # ash_money instead: `AshMoney.Types.Money.json_schema/1` documents
+  # `{amount: string, currency: string}`, with `amount` a decimal string, and
+  # its `Jason.Encoder` sends exactly those two keys. These assertions hold the
+  # generated class to it, and to the name the mapper emits — a field typed
+  # `AshMoney` with no `AshMoney` class does not compile (#30).
+  describe "AshMoney" do
+    test "the mapper names a class the generator declares" do
+      assert TypeMapper.get_kotlin_type_for_type(AshMoney.Types.Money) == "AshMoney"
+
+      kotlin = KotlinStatic.generate_money_type()
+
+      assert kotlin =~ "data class AshMoney("
+      assert kotlin =~ "val amount: String"
+      assert kotlin =~ "val currency: String"
     end
   end
 end

--- a/test/fixtures/kotlin_compile/roundtrip/Roundtrip.kt
+++ b/test/fixtures/kotlin_compile/roundtrip/Roundtrip.kt
@@ -95,6 +95,23 @@ private fun untypedMapKeepsNumberLiterals(): String {
     return "re-encoded unchanged: $sent"
 }
 
+// #30: `:vector` reached Kotlin as JsonElement, so a caller unpacked the numbers
+// by hand. It is `List<Double>` now.
+//
+// A literal, not a fixture entry, because no Runner response can carry a vector
+// yet: #71 measured that `%Ash.Vector{}` reaches the encoder as its packed
+// binary and raises Jason.EncodeError. This is the number array the server will
+// send once it does, so the Kotlin half is checked now and the fixture entry
+// lands with #71.
+private fun vectorDecodesAsDoubles(): String {
+    val sent = """{"id":"1","embedding":[0.25,-1.5,3.0]}"""
+    val todo = ashRpcJson.decodeFromString<Todo>(sent)
+
+    expect("embedding", todo.embedding, listOf(0.25, -1.5, 3.0))
+
+    return "embedding=${todo.embedding}"
+}
+
 // #54: dataAs() is the documented way to get a typed value out of a result, and
 // it built a Json of its own that carried no SerializersModule.
 private fun dateFieldsViaDataAs(): String {
@@ -367,6 +384,7 @@ private fun refusedReadParametersDecode(): String {
 fun main() {
     check("#51 populated untyped map via dataAs()", ::populatedUntypedMap)
     check("#51 untyped map keeps number literals", ::untypedMapKeepsNumberLiterals)
+    check("#30 a vector decodes as a list of doubles", ::vectorDecodesAsDoubles)
     check("#54 date fields via dataAs()", ::dateFieldsViaDataAs)
     check("#54 date fields through the channel client's Json", ::dateFieldsThroughTheChannelJson)
     check("#54 input encoding through the shared Json", ::inputEncoding)

--- a/test/support/resources/todo.ex
+++ b/test/support/resources/todo.ex
@@ -7,11 +7,13 @@ defmodule AshKotlinMultiplatform.Test.Todo do
   Carries the attribute types that have no direct Kotlin equivalent.
 
   `Ash.Type.Map`, `Ash.Type.Keyword`, `Ash.Type.Tuple`, `Ash.Type.Union` and any
-  Ash type the mapper does not recognise all reach Kotlin as `Any`, which
-  kotlinx-serialization refuses inside a `@Serializable` class ("Serializer has
-  not been found for type 'Any'"). `:status` is public for the matching reason on
-  the other side: an `:atom` with `one_of` has an enum class generated for it, so
-  the field has to name that class rather than `String`.
+  Ash type the mapper does not recognise all reach Kotlin as `JsonElement`, which
+  is what they took after `Any` proved to be a compile error inside a
+  `@Serializable` class and then a decode-time throw (#50, #51). `:embedding` is
+  the other side of that: a type the mapper used to miss and now names. `:status`
+  is public for a different reason again — an `:atom` with `one_of` has an enum
+  class generated for it, so the field has to name that class rather than
+  `String`.
 
   Only `Ash.Resource.Info.public_attributes/1` reaches the generator, hence
   `public? true` on every attribute that is here to be generated.
@@ -69,6 +71,15 @@ defmodule AshKotlinMultiplatform.Test.Todo do
     # unknown-type fallback rather than any of the branches above.
     attribute :scratch, Ash.Type.Term, public?: true
 
+    # A pgvector embedding: the attribute that puts `List<Double>` in the
+    # generated Kotlin, so the compile gate covers it (#30). It carries no value
+    # in the round-trip fixture, because a vector response raises
+    # `Jason.EncodeError` until #71 lands.
+    attribute :embedding, :vector do
+      constraints dimensions: 3
+      public? true
+    end
+
     attribute :due_date, :date
 
     attribute :completed_at, :utc_datetime
@@ -100,7 +111,8 @@ defmodule AshKotlinMultiplatform.Test.Todo do
         :tags,
         :user_id,
         :metadata,
-        :settings
+        :settings,
+        :embedding
       ]
     end
 


### PR DESCRIPTION
Closes #30.

`TypeMapper` sent four common Ash types to the unknown-type fallback, so a
vector, money, ltree or ULID field arrived in a generated client as an opaque
`JsonElement` the caller unpacked by hand. Each now has a Kotlin type.

| Ash type | Kotlin | Upstream |
| -------- | ------ | -------- |
| `Ash.Type.Vector` | `List<Double>` | `ab2ce96` |
| `AshMoney.Types.Money` | `AshMoney` | `3f02631` |
| `AshPostgres.Ltree` | `List<String>` | `3f02631` |
| `AshDoubleEntry.ULID` | `String` | `3f02631` |

`AshMoney` is new: `KotlinStatic.generate_money_type/0` emits a
`@Serializable` data class with an `amount: String` and a `currency: String`
into every generated file. Naming a Kotlin type is only half the fix — a
field typed `AshMoney` in a file that declares no such class does not
compile. The shape is ash_money's own: its `Jason.Encoder` sends `currency`
and `amount` and nothing else, and `AshMoney.Types.Money.json_schema/1`
documents both as strings. `amount` stays a `String` for the reason
`Ash.Type.Decimal` is one — reading a currency amount into a `Double` would
round it.

Two places where this reads upstream and lands somewhere else:

* Upstream calls the TypeScript alias `Money`. `AshMoney` here follows the
  prefix the generated file already uses for its own shared classes —
  `AshRpcError`, `AshPage`, `AshMetadata`.
* Upstream types an unescaped ltree `string | string[]`, because
  `AshPostgres.Ltree.cast_input/2` also accepts a dotted string. Kotlin has
  no untagged union. The value is a list of segments in memory under both
  `escape?` settings, so `List<String>` types the output either way and a
  generated client always sends segments.

## A vector still cannot be sent — #71

The ticket asked for `8ebc8cc`'s wire half too, and it is already in the
shared core: `AshIntrospection.Rpc.ValueFormatter.format_vector/1` expands
`%Ash.Vector{}` with `Ash.Vector.to_list/1`. Nothing in this library calls
it. `Rpc.Runner.execute_action/7` formats output with
`Pipeline.format_output/1`, which renames keys and stops, so a vector reaches
the JSON encoder as its packed binary:

```
** (Jason.EncodeError) invalid byte 0x80 in
   <<0, 3, 0, 0, 62, 128, 0, 0, 191, 192, 0, 0, 64, 64, 0, 0>>
```

Measured 2026-09-11 while adding a round-trip fixture entry for it. Filed as
#71 with the repro, because the fix is not a one-line swap: the type-aware
entry point builds an envelope `Runner` already builds, and passes a list of
records through untouched, so a list read would lose the field-name
formatting it has today. This PR ships the Kotlin type; #71 makes the server
able to send one.

The round-trip check for the vector therefore decodes a literal rather than a
fixture response, and says so. `Todo` gains an `:embedding` attribute so the
compile gate covers `List<Double>`.

## Test plan

Every gate CI runs, on `6c8d63e`:

| Command | Result |
| ------- | ------ |
| `mix compile --force --warnings-as-errors` | clean, no warnings |
| `mix test` | 229 tests, 0 failures (225 before this branch) |
| `mix hex.audit` | No retired packages found |
| `mix deps.audit` | No vulnerabilities found |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` | both `:datetime_library` subprojects written |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_roundtrip_fixture` | 21 responses |
| `gradle compileKotlin` (JDK 21, Gradle 9.7) | BUILD SUCCESSFUL, exit 0, no `w:` or `e:` lines |
| `gradle run` | BUILD SUCCESSFUL, 48 PASS, 0 FAIL (24 checks x 2 subprojects) |

TDD, one red/green pair per commit. The three failing tests that opened the
branch — Money, Ltree, ULID against `"JsonElement"` — were reproduced before
any clause was written.

`mix format --check-formatted` still fails on the same eight files it fails
on for `main` (#38). None is touched here.

## Docs

`docs/roadmap.md` moves #30 to Shipped and adds #71 to Next.
`docs/architecture.md` names `AshMoney` in the `KotlinStatic` box and states
the rule behind it. `docs/risks.md` gains the value-formatter gap.
`docs/decisions.md` records the four type choices and their cost.
`CLAUDE.md` gains the lesson that the runner formats names and not values.
