### PR TITLE
Reject get_by on an action that is not a read (#69)

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -456,3 +456,21 @@ Upstream added a `persistent_term` spec cache in `199f9cd` and deleted it in
 state. `Spark.Dsl.Extension.get_persisted/3` reads a compiled module attribute,
 which is already free at runtime, so a second cache would buy nothing and add a
 second thing to go stale. Not ported.
+
+## 2026-09-12 — `get_by` is a read-only option, enforced at compile time
+
+`get_by` names the fields a client sends to select one record. The generator
+emits that field for read actions only
+(`Rpc.Codegen.Helpers.ConfigBuilder.get_action_context/3`), so the other half of
+the DSL had two ways to go: teach the generator to emit `getBy` for writes, or
+refuse the combination. `Rpc.Verifiers.VerifyIdentities` now refuses it (#69).
+
+Why: an update or destroy already has a lookup key — `identities` — and a
+create looks up nothing. A second lookup mechanism on the same action would
+give two DSL options that select a record, with no rule saying which wins. The
+old behaviour was worse than either: the action compiled, shipped a client that
+could not send the field, and failed every call with `{:missing_get_by_fields,
+...}`.
+
+Cost: a project that set `get_by` on a write and never called the action now
+fails to compile. That build was already broken; it just had not been run yet.

--- a/docs/risks.md
+++ b/docs/risks.md
@@ -94,21 +94,6 @@ declares only the v1 serializer.
 *Do:* nothing for the stock Phoenix socket, which offers both. A host that
 narrowed `serializer:` to v1 must add v2.
 
-### `get_by` on an action that is not a read fails only at runtime
-
-`VerifyIdentities` checks `get_by` on read actions only, and
-`ConfigBuilder.get_action_context/3` zeroes it for every other type. So
-`get_by [:id]` on a create, update or destroy compiles clean and generates a
-config class with no lookup field — and then `Rpc.Runner`'s `parse_get_by`,
-which runs on every action type, finds the configured field missing from the
-request and refuses the call. Every call to that action fails, and nothing
-said so at compile time.
-
-*Watch:* nothing. No test covers the combination.
-*Do:* extend the read branch of `VerifyIdentities` to reject a non-empty
-`get_by` on any action that is not a read, so the DSL entry breaks the build
-instead of the client.
-
 ### `main` is not formatter-clean
 
 `mix format --check-formatted` fails on ten files that predate the current

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -36,6 +36,7 @@ afterwards.
 | 2026-09-11 | Kotlin types for vector, money, ltree and ULID, plus the `AshMoney` class a money field needs (#30) |
 | 2026-09-11 | Stage 4 formats output values by Ash type, so a vector response encodes; `field_names` honoured on both sides (#71) |
 | 2026-09-12 | `AshKotlinMultiplatform.Manifest`: one compile-time `Ash.Info.Manifest`, decorated and persisted (#73) |
+| 2026-09-12 | `get_by` on a create, update or destroy is a compile error rather than a runtime failure on every call (#69) |
 
 ## In progress
 

--- a/lib/ash_kotlin_multiplatform/rpc.ex
+++ b/lib/ash_kotlin_multiplatform/rpc.ex
@@ -193,7 +193,8 @@ defmodule AshKotlinMultiplatform.Rpc do
       ],
       get_by: [
         type: {:wrap_list, :atom},
-        doc: "Fields the client sends to select one record. Implies `get?`. Read actions only",
+        doc:
+          "Fields the client sends to select one record. Implies `get?`. Read actions only — on a create, update or destroy it is a compile error",
         default: []
       ],
       not_found_error?: [

--- a/lib/ash_kotlin_multiplatform/rpc/runner.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/runner.ex
@@ -296,6 +296,12 @@ defmodule AshKotlinMultiplatform.Rpc.Runner do
   # rest, and `Ash.read_one/1` answers that with a `MultipleResults` naming
   # nothing the caller can act on; an extra field would reach
   # `Ash.Query.do_filter/2` as an arbitrary predicate.
+  #
+  # No action-type guard here on purpose. `Rpc.Verifiers.VerifyIdentities`
+  # refuses to compile a `get_by` on anything but a read (#69), so on a create,
+  # update or destroy `allowed` is the schema default `[]` and this returns
+  # `{:ok, nil}`. A guard would be a branch no test can reach without disabling
+  # the verifier.
   defp parse_get_by(params, rpc_action, resource) do
     allowed = configured_get_by(rpc_action)
     sent = normalize_get_by(params["getBy"], resource)

--- a/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex
@@ -15,6 +15,14 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
   * `get_by` on a read — each must be a public attribute. The generated `GetBy`
     data class takes its Kotlin type from that attribute, so a name that is not
     one has no type to emit.
+
+  `get_by` on anything other than a read is also rejected here (#69). The
+  generator emits the `getBy` config field for read actions only
+  (`Rpc.Codegen.Helpers.ConfigBuilder.get_action_context/3`), so a create,
+  update or destroy carrying `get_by` compiled clean, shipped a client that
+  could not send the field, and failed every call with
+  `{:missing_get_by_fields, ...}`. A compile error at the offending line beats a
+  runtime error on every request.
   """
   use Spark.Dsl.Verifier
   alias Spark.Dsl.Verifier
@@ -50,15 +58,27 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
       is_nil(action) ->
         errors
 
-      action.type in [:update, :destroy] ->
-        identities = Map.get(rpc_action, :identities, [:_primary_key])
-        validate_identities_exist(resource, rpc_action, identities, errors)
-
       action.type == :read ->
         validate_get_by_fields(resource, rpc_action, errors)
 
+      action.type in [:update, :destroy] ->
+        identities = Map.get(rpc_action, :identities, [:_primary_key])
+
+        errors = validate_get_by_absent(rpc_action, action, errors)
+        validate_identities_exist(resource, rpc_action, identities, errors)
+
       true ->
+        validate_get_by_absent(rpc_action, action, errors)
+    end
+  end
+
+  defp validate_get_by_absent(rpc_action, action, errors) do
+    case rpc_action |> Map.get(:get_by) |> List.wrap() do
+      [] ->
         errors
+
+      fields ->
+        [{:get_by_on_non_read, rpc_action.name, rpc_action.action, action.type, fields} | errors]
     end
   end
 
@@ -131,9 +151,19 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
        #{message_parts}
 
        Each identity listed in the `identities` option must either be `:_primary_key` (for the resource's primary key)
-       or the name of an identity defined on the resource. Each field listed in `get_by` must be a public attribute.
+       or the name of an identity defined on the resource. Each field listed in `get_by` must be a public attribute,
+       and `get_by` may only be set on a read action.
        """
      )}
+  end
+
+  defp format_error_part({:get_by_on_non_read, rpc_name, action_name, action_type, fields}) do
+    """
+    get_by is set on an action that is not a read:
+      - RPC action: #{rpc_name} (action: #{action_name}, type: #{inspect(action_type)})
+      - Fields: #{Enum.map_join(fields, ", ", &inspect/1)}
+      - #{get_by_replacement(action_type)}
+    """
   end
 
   defp format_error_part({:get_by_not_an_attribute, rpc_name, field, public_attributes}) do
@@ -180,4 +210,11 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentities do
       - Either define a primary key on the resource, use a named identity, or use `identities: []` for actor-scoped actions.
     """
   end
+
+  defp get_by_replacement(type) when type in [:update, :destroy],
+    do:
+      "Use `identities` to name the lookup key for an update or destroy. `get_by` selects a record on a read only."
+
+  defp get_by_replacement(_type),
+    do: "A create looks up no record. Remove `get_by` from this action."
 end

--- a/test/ash_kotlin_multiplatform/rpc/verifiers/verify_identities_test.exs
+++ b/test/ash_kotlin_multiplatform/rpc/verifiers/verify_identities_test.exs
@@ -24,6 +24,10 @@ defmodule AshKotlinMultiplatform.Test.VerifyIdentities.Article do
     defaults [:read, :destroy]
     default_accept [:slug]
 
+    create :publish do
+      accept [:slug]
+    end
+
     update :rename do
       accept [:slug]
     end
@@ -148,6 +152,126 @@ defmodule AshKotlinMultiplatform.Rpc.Verifiers.VerifyIdentitiesTest do
       assert error.message =~ "get_by field is not a public attribute"
       assert error.message =~ "draft_note"
       assert error.message =~ "slug"
+    end
+  end
+
+  # `get_by` is read on every action type but was validated on reads only, so a
+  # create, update or destroy carrying it compiled clean, generated a client
+  # with no `getBy` field, and then failed every call with
+  # `{:missing_get_by_fields, ...}` (#69). The DSL accepted something it could
+  # not serve. Compile-time rejection moves the failure to the line that caused
+  # it.
+  describe "get_by on an action that is not a read" do
+    test "rejects it on a create" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.GetByCreateDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource Article
+            end
+
+            kotlin_rpc do
+              resource Article do
+                rpc_action :publish_article, :publish do
+                  get_by [:slug]
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "get_by is set on an action that is not a read"
+      assert error.message =~ "publish_article"
+      assert error.message =~ ":create"
+      assert error.message =~ ":slug"
+    end
+
+    test "rejects it on an update" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.GetByUpdateDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource Article
+            end
+
+            kotlin_rpc do
+              resource Article do
+                rpc_action :rename_article, :rename do
+                  get_by [:slug]
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "get_by is set on an action that is not a read"
+      assert error.message =~ "rename_article"
+      assert error.message =~ ":update"
+      assert error.message =~ "identities"
+    end
+
+    test "rejects it on a destroy" do
+      error =
+        assert_dsl_error do
+          defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.GetByDestroyDomain do
+            @moduledoc false
+            use Ash.Domain,
+              extensions: [AshKotlinMultiplatform.Rpc],
+              validate_config_inclusion?: false
+
+            resources do
+              resource Article
+            end
+
+            kotlin_rpc do
+              resource Article do
+                rpc_action :destroy_article, :destroy do
+                  get_by [:slug]
+                end
+              end
+            end
+          end
+        end
+
+      assert error.message =~ "get_by is set on an action that is not a read"
+      assert error.message =~ "destroy_article"
+      assert error.message =~ ":destroy"
+      assert error.message =~ "identities"
+    end
+
+    # The name is a public attribute, so this is not the existing
+    # `get_by_not_an_attribute` error firing under a different heading.
+    test "accepts a create, update and destroy that set no get_by" do
+      refute_dsl_errors do
+        defmodule Elixir.AshKotlinMultiplatform.Test.VerifyIdentities.NoGetByWritesDomain do
+          @moduledoc false
+          use Ash.Domain,
+            extensions: [AshKotlinMultiplatform.Rpc],
+            validate_config_inclusion?: false
+
+          resources do
+            resource Article
+          end
+
+          kotlin_rpc do
+            resource Article do
+              rpc_action(:publish_article, :publish)
+              rpc_action(:rename_article, :rename)
+              rpc_action(:destroy_article, :destroy)
+            end
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
`get_by` was validated on read actions only and read on every action type. A
create, update or destroy carrying it compiled clean, generated a client with no
`getBy` field, and then refused every call at runtime. This makes it a compile
error at the line that caused it.

Closes #69

## The bug

Three places disagreed:

- `lib/ash_kotlin_multiplatform/rpc/verifiers/verify_identities.ex` —
  `validate_get_by_fields/3` ran in the `action.type == :read` branch only.
  `:update` and `:destroy` fell to the `identities` branch, `:create` to the
  catch-all.
- `lib/ash_kotlin_multiplatform/rpc/codegen/helpers/config_builder.ex:46` —
  `get_by = if action.type == :read, do: ..., else: []`, so the generated config
  class carried no `getBy` field and no client could send one.
- `lib/ash_kotlin_multiplatform/rpc/runner.ex` — `parse_get_by/2` compared the
  configured list against what the client sent. `allowed` was non-empty, `sent`
  was empty, so every call returned `{:error, {:missing_get_by_fields, ...}}`.

## The fix

`Rpc.Verifiers.VerifyIdentities` now errors when `get_by` is non-empty on an
action that is not a read. The message names the rpc_action, the action, its
type, the fields, and what to use instead:

```
get_by is set on an action that is not a read:
  - RPC action: rename_article (action: rename, type: :update)
  - Fields: :slug
  - Use `identities` to name the lookup key for an update or destroy. `get_by`
    selects a record on a read only.
```

For a create the hint is "A create looks up no record. Remove `get_by` from
this action."

## `parse_get_by/2` stays as it is

I left it with no action-type guard and added a comment saying why.

With the verifier in place a non-read's `get_by` is the schema default `[]`, so
`allowed == []` and `parse_get_by/2` already returns `{:ok, nil}` on the first
`cond` branch that can match. Adding `action.type == :read` there would create a
branch no test can reach without disabling the verifier — untestable defensive
code guarding a state the compiler now rejects. The comment names the verifier
as the guarantee, so the next reader does not mistake the absence for an
oversight.

## Docs

- `docs/risks.md` — the entry describing this exact bug is deleted, not marked
  closed.
- `docs/roadmap.md` — shipped row.
- `docs/decisions.md` — why `get_by` stays read-only rather than the generator
  learning to emit `getBy` for writes. An update or destroy already has
  `identities`; a create looks up nothing. Two DSL options selecting a record
  with no rule saying which wins is worse than one.

## Test plan

Every gate `.github/workflows/ci.yml` runs, run locally on this branch.

| Command | Result |
| ------- | ------ |
| `mix compile --warnings-as-errors` | clean |
| `mix test` | 295 tests, 0 failures |
| `mix hex.audit` | No retired packages found |
| `mix deps.audit` | No vulnerabilities found |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` | exit 0 |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_roundtrip_fixture` | exit 0 |
| `gradle compileKotlin` (test/fixtures/kotlin_compile) | BUILD SUCCESSFUL |
| `gradle run` (test/fixtures/kotlin_compile) | BUILD SUCCESSFUL, 54 PASS, 0 FAIL |

New tests in
`test/ash_kotlin_multiplatform/rpc/verifiers/verify_identities_test.exs`, written
first and confirmed red before the fix (3 failures, "Expected a
Spark.Error.DslError ... Got: []"):

- `get_by` on a create fails verification, naming the action and `:create`
- `get_by` on an update fails, naming the action, `:update` and `identities`
- `get_by` on a destroy fails, naming the action, `:destroy` and `identities`
- a create, update and destroy with no `get_by` still verify
- the two existing read cases are untouched and still pass

The file went from 5 tests to 8.

No project-wide `mix format`: `main` is not formatter-clean (#38) and
`.formatter.exs` carries no `locals_without_parens` for this DSL, so a full run
rewrites unrelated files and mangles `rpc_action :list_todos, :read` into a
function call. Only the four changed files were formatted.
