### PR TITLE
fix: make main formatter-clean and enforce it in CI (#38)

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,33 @@
+spark_locals_without_parens = [
+  argument_names: 1,
+  enable_filter?: 1,
+  enable_sort?: 1,
+  field_names: 1,
+  fields: 1,
+  get?: 1,
+  get_by: 1,
+  identities: 1,
+  kotlin_fields_const_name: 1,
+  kotlin_result_type_name: 1,
+  metadata_field_names: 1,
+  not_found_error?: 1,
+  read_action: 1,
+  resource: 1,
+  resource: 2,
+  rpc_action: 2,
+  rpc_action: 3,
+  show_metadata: 1,
+  type_name: 1,
+  typed_query: 2,
+  typed_query: 3
+]
+
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
-  import_deps: [:ash, :ash_phoenix, :spark]
+  import_deps: [:ash, :ash_phoenix, :spark],
+  locals_without_parens: spark_locals_without_parens,
+  export: [
+    locals_without_parens: spark_locals_without_parens
+  ]
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Compile (warnings as errors)
         run: mix compile --warnings-as-errors
 
+      - name: Check formatting
+        run: mix format --check-formatted
+
       - name: Run tests
         run: mix test
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,11 +63,22 @@ Since #52 the `kotlin-compile-gate` job has no `continue-on-error`, and both
 Any warning or error is yours. Run both before pushing a generator change;
 the CI job will not merge without them.
 
-### `mix format --check-formatted` fails on `main`
+### Gradle and Java are not on the global mise path
 
-Ten files predate the current formatter rules (#38), so a red check does not
-mean you broke something. Run `mix format` on the files you touched and check
-the failing list is unchanged, not empty.
+`kotlin-compile-gate` steps (`gradle compileKotlin`, `gradle run` in
+`test/fixtures/kotlin_compile`) fail with "command not found" under a bare
+`mise exec --` because gradle and java aren't installed there globally.
+Prefix every such command with
+`mise exec gradle@9.7.0 java@temurin-21 --` (#38).
+
+### `.formatter.exs` needs `locals_without_parens` for this library's DSL
+
+Without it, `mix format` rewrites `rpc_action :list_todos, :read` into
+`rpc_action(:list_todos, :read)` in test resources and README examples,
+making DSL calls read like function calls. Regenerate the list with
+`mix spark.formatter --extensions AshKotlinMultiplatform.Rpc,AshKotlinMultiplatform.Resource,AshKotlinMultiplatform.Manifest.Dsl`
+after adding or changing a DSL entity or option — never hand-edit the
+`spark_locals_without_parens` list (#38).
 
 ### The channel client is hand-written Phoenix protocol, not kotlinx
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,6 +37,7 @@ afterwards.
 | 2026-09-11 | Stage 4 formats output values by Ash type, so a vector response encodes; `field_names` honoured on both sides (#71) |
 | 2026-09-12 | `AshKotlinMultiplatform.Manifest`: one compile-time `Ash.Info.Manifest`, decorated and persisted (#73) |
 | 2026-09-12 | `get_by` on a create, update or destroy is a compile error rather than a runtime failure on every call (#69) |
+| 2026-09-13 | `main` is formatter-clean; `mix format --check-formatted` is in CI (#38) |
 
 ## In progress
 
@@ -51,7 +52,6 @@ Ordered by what unblocks the most.
 | Issue | What | Why now |
 | ----- | ---- | ------- |
 | `ash_introspection#23` stage 4 | Delete `AshIntrospection.Codegen.TypeDiscovery`; codegen reads the manifest only | Stage 3 built the manifest; nothing reads it on the request path yet |
-| #38 | Make `main` formatter-clean and put the check in CI | One mechanical commit; unblocks review signal |
 | #65, #53 | Typed `filter` and `page` in the request config | The response is typed now; the request still takes untyped maps, so `FilterTypes` is dead code |
 | #48, #53 | The runner mangles unconstrained map keys on the way IN; FilterTypes emits unpublished resources | #71 fixed the output half: an untyped map's keys now survive as written, but `Runner` parses `input` before it knows a field's type, so a key sent as `createdBy` is still stored as `created_by` |
 | #57 | Error keys ignore the output field formatter | The decode gate now reads those keys |

--- a/lib/ash_kotlin_multiplatform/codegen/typed_queries.ex
+++ b/lib/ash_kotlin_multiplatform/codegen/typed_queries.ex
@@ -209,7 +209,9 @@ defmodule AshKotlinMultiplatform.Codegen.TypedQueries do
       rel = Ash.Resource.Info.relationship(resource, field)
 
       if rel do
-        nested_type_name = "#{parent_type_name}#{AshIntrospection.Helpers.snake_to_pascal_case(field)}Result"
+        nested_type_name =
+          "#{parent_type_name}#{AshIntrospection.Helpers.snake_to_pascal_case(field)}Result"
+
         formatted_name = format_field_for_client(field, resource)
 
         if rel.cardinality == :many do
@@ -228,7 +230,9 @@ defmodule AshKotlinMultiplatform.Codegen.TypedQueries do
     rel = Ash.Resource.Info.relationship(resource, field)
 
     if rel do
-      nested_type_name = "#{parent_type_name}#{AshIntrospection.Helpers.snake_to_pascal_case(field)}Result"
+      nested_type_name =
+        "#{parent_type_name}#{AshIntrospection.Helpers.snake_to_pascal_case(field)}Result"
+
       formatted_name = format_field_for_client(field, resource)
 
       if rel.cardinality == :many do
@@ -271,7 +275,9 @@ defmodule AshKotlinMultiplatform.Codegen.TypedQueries do
     rel = Ash.Resource.Info.relationship(resource, field)
 
     if rel do
-      nested_type_name = "#{parent_type_name}#{AshIntrospection.Helpers.snake_to_pascal_case(field)}Result"
+      nested_type_name =
+        "#{parent_type_name}#{AshIntrospection.Helpers.snake_to_pascal_case(field)}Result"
+
       [{rel.destination, nested_fields, nested_type_name}]
     else
       []
@@ -330,6 +336,7 @@ defmodule AshKotlinMultiplatform.Codegen.TypedQueries do
       "mapOf(\"#{format_field_for_client(field, resource)}\" to #{nested})"
     else
       args_json = format_args_for_kotlin(args, resource)
+
       "mapOf(\"#{format_field_for_client(field, resource)}\" to mapOf(\"args\" to #{args_json}, \"fields\" to #{nested}))"
     end
   end
@@ -351,7 +358,9 @@ defmodule AshKotlinMultiplatform.Codegen.TypedQueries do
   defp encode_kotlin_value(v) when is_number(v), do: to_string(v)
   defp encode_kotlin_value(v) when is_boolean(v), do: to_string(v)
   defp encode_kotlin_value(nil), do: "null"
-  defp encode_kotlin_value(v) when is_list(v), do: "listOf(#{Enum.map_join(v, ", ", &encode_kotlin_value/1)})"
+
+  defp encode_kotlin_value(v) when is_list(v),
+    do: "listOf(#{Enum.map_join(v, ", ", &encode_kotlin_value/1)})"
 
   defp encode_kotlin_value(v) when is_map(v) do
     items =

--- a/lib/ash_kotlin_multiplatform/phoenix/controller.ex
+++ b/lib/ash_kotlin_multiplatform/phoenix/controller.ex
@@ -145,20 +145,38 @@ defmodule AshKotlinMultiplatform.Phoenix.Controller do
     if require_auth and is_nil(actor) do
       handle_unauthorized.(conn)
     else
-      result = AshKotlinMultiplatform.Rpc.Runner.run_action(otp_app, params, actor: actor, tenant: tenant)
+      result =
+        AshKotlinMultiplatform.Rpc.Runner.run_action(otp_app, params,
+          actor: actor,
+          tenant: tenant
+        )
+
       Phoenix.Controller.json(conn, result)
     end
   end
 
   @doc false
-  def handle_validate(conn, params, otp_app, get_actor, get_tenant, handle_unauthorized, require_auth) do
+  def handle_validate(
+        conn,
+        params,
+        otp_app,
+        get_actor,
+        get_tenant,
+        handle_unauthorized,
+        require_auth
+      ) do
     actor = get_actor.(conn)
     tenant = get_tenant.(conn)
 
     if require_auth and is_nil(actor) do
       handle_unauthorized.(conn)
     else
-      result = AshKotlinMultiplatform.Rpc.Runner.validate_action(otp_app, params, actor: actor, tenant: tenant)
+      result =
+        AshKotlinMultiplatform.Rpc.Runner.validate_action(otp_app, params,
+          actor: actor,
+          tenant: tenant
+        )
+
       Phoenix.Controller.json(conn, result)
     end
   end

--- a/lib/ash_kotlin_multiplatform/resource/verifiers/verify_unique_type_names.ex
+++ b/lib/ash_kotlin_multiplatform/resource/verifiers/verify_unique_type_names.ex
@@ -32,7 +32,9 @@ defmodule AshKotlinMultiplatform.Resource.Verifiers.VerifyUniqueTypeNames do
         end)
         |> Enum.uniq()
         |> Enum.map(fn resource ->
-          type_name = AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_type_name!(resource)
+          type_name =
+            AshKotlinMultiplatform.Resource.Info.kotlin_multiplatform_type_name!(resource)
+
           {type_name, resource}
         end)
 

--- a/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
+++ b/lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
@@ -180,7 +180,9 @@ defmodule AshKotlinMultiplatform.Rpc.Codegen.TypeGenerators.MetadataTypes do
           # Check for mapped metadata field names
           metadata_field_names = Map.get(rpc_action, :metadata_field_names, [])
 
-          mapped_name = Keyword.get(metadata_field_names, metadata_field.name, metadata_field.name)
+          mapped_name =
+            Keyword.get(metadata_field_names, metadata_field.name, metadata_field.name)
+
           formatted_name = Helpers.snake_to_camel_case(mapped_name)
 
           # Add @SerialName if the formatted name differs from the original

--- a/lib/ash_kotlin_multiplatform/swift/codegen.ex
+++ b/lib/ash_kotlin_multiplatform/swift/codegen.ex
@@ -239,7 +239,9 @@ defmodule AshKotlinMultiplatform.Swift.Codegen do
     case type do
       Ash.Type.Atom ->
         case Keyword.get(constraints, :one_of) do
-          nil -> {enums, embedded}
+          nil ->
+            {enums, embedded}
+
           values ->
             enum_name = generate_enum_name(attr.name)
             {[{enum_name, values} | enums], embedded}

--- a/test/ash_kotlin_multiplatform/swift/type_mapper_test.exs
+++ b/test/ash_kotlin_multiplatform/swift/type_mapper_test.exs
@@ -38,7 +38,7 @@ defmodule AshKotlinMultiplatform.Swift.TypeMapperTest do
 
     test "maps atom type to String" do
       assert TypeMapper.get_swift_type_for_type(Ash.Type.Atom, []) == "String"
-      assert TypeMapper.get_swift_type_for_type(Ash.Type.Atom, [one_of: [:a, :b]]) == "String"
+      assert TypeMapper.get_swift_type_for_type(Ash.Type.Atom, one_of: [:a, :b]) == "String"
     end
   end
 


### PR DESCRIPTION
Closes #38

## Problem

`main` was not formatter-clean: `mix format --check-formatted` failed on
8 files, so the check could not go into CI, and every contributor's
`mix format` rewrote files they had not touched. Two agents lost time to
this on 2026-09-11 and 2026-09-12 (see the issue comments).

## The trap, and the order this PR follows

`.formatter.exs` carried no `locals_without_parens` for this library's own
Spark DSL. A plain `mix format` before fixing that would have rewritten
`rpc_action :list_todos, :read` into `rpc_action(:list_todos, :read)` in
the test resources, `test/support/test_domain.ex`, and the README examples
that teach the DSL — making formatting land as a regression, not a fix.

So this PR does the three steps in order, one commit each:

1. `a28dfac` — add `locals_without_parens` to `.formatter.exs`, generated
   with `mix spark.formatter --extensions
   AshKotlinMultiplatform.Rpc,AshKotlinMultiplatform.Resource,AshKotlinMultiplatform.Manifest.Dsl`
   rather than hand-written, mirroring the pattern in `deps/ash/.formatter.exs`.
   Config only — no file reformatted yet.
2. `d23a033` — run `mix format` once. Touches exactly the 6 files that
   still failed after step 1 (plain line-length wraps); the 2 files that
   failed only for DSL parens (`test/support/test_domain.ex`,
   `test/support/resources/user.ex`) were already fixed by step 1 alone,
   confirming the config change worked before any reformat ran.
3. `b1d5f39` — add `mix format --check-formatted` to the `test` job in
   `.github/workflows/ci.yml`, next to the other static checks.

Two more commits: `9d3fe99` updates `CLAUDE.md` — drops the now-stale
"format check fails on main" lesson and records the gradle/java mise
lesson this run rediscovered — and `bc125d4` moves #38 from Next to
Shipped on `docs/roadmap.md`.

## Verification that step 2 changed only whitespace

`git diff --ignore-all-space` is not literally empty, because reflowing a
long line into several lines inserts new line boundaries (and sometimes a
blank line) that `--ignore-all-space` still counts as a diff — it only
ignores whitespace within a line, not added lines. So I verified with an
AST comparison instead, per the issue's own suggestion: for each of the 6
changed files, parse the before and after source with
`Code.string_to_quoted!/1`, strip all AST metadata (line/column info), and
compare. All 6 come back structurally identical:

```
IDENTICAL AST: lib/ash_kotlin_multiplatform/codegen/typed_queries.ex
IDENTICAL AST: lib/ash_kotlin_multiplatform/phoenix/controller.ex
IDENTICAL AST: lib/ash_kotlin_multiplatform/resource/verifiers/verify_unique_type_names.ex
IDENTICAL AST: lib/ash_kotlin_multiplatform/rpc/codegen/type_generators/metadata_types.ex
IDENTICAL AST: lib/ash_kotlin_multiplatform/swift/codegen.ex
IDENTICAL AST: test/ash_kotlin_multiplatform/swift/type_mapper_test.exs
```

The one line that reads like a behavior change,
`get_swift_type_for_type(Ash.Type.Atom, [one_of: [:a, :b]])` becoming
`get_swift_type_for_type(Ash.Type.Atom, one_of: [:a, :b])`, is the
formatter dropping the optional brackets around a trailing keyword-list
argument — same AST, same call.

No DSL call gained parens. Confirmed with
`grep -rn "rpc_action(" lib/ test/ README.md` after formatting: the only
hits are pre-existing parenthesized calls in two verifier tests that
already had parens before this PR and were not touched by it (parens are
legal Elixir either way; `locals_without_parens` only stops the formatter
from *adding* parens to a call written without them — it does not strip
parens that were already there).

## Test plan

All run from
`~/.claude_worktrees/ash_kotlin_multiplatform-issue-38` with
`mise exec -- mix ...` unless noted.

| Command | Result |
| --- | --- |
| `mix format --check-formatted` | exit 0, no output |
| `mix compile --warnings-as-errors` | clean compile, no warnings |
| `mix test` | 295 tests, 0 failures |
| `mix hex.audit` | No retired packages found |
| `mix deps.audit` | No vulnerabilities found |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_kotlin_fixture` | generated; `git status` on `test/fixtures/kotlin_compile/**/*.kt` shows no diff — byte-identical to `main` |
| `MIX_ENV=test mix ash_kotlin_multiplatform.gen_roundtrip_fixture` | generated `responses.json` (23 responses); `git status` shows no diff — byte-identical to `main` |
| `mise exec gradle@9.7.0 java@temurin-21 -- gradle compileKotlin --console=plain` (in `test/fixtures/kotlin_compile`) | BUILD SUCCESSFUL |
| `mise exec gradle@9.7.0 java@temurin-21 -- gradle run --console=plain` (same dir) | BUILD SUCCESSFUL, all `PASS` lines for both `java-time` and `kotlinx-datetime` subprojects |

Gradle and Java are not on the global mise path in this environment —
`mise exec gradle@9.7.0 java@temurin-21 --` is required, and is now
recorded in `CLAUDE.md`.

The round-trip and Kotlin-compile fixtures staying byte-identical to
`main` confirms the formatter sweep changed no generated output — the gate
CI's own comment warns about (#20, #23, #30, #33, #44, #45, #24, #51, #54,
#58) never fires here.
